### PR TITLE
fix(ci): Set GH_TOKEN secret

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,15 +54,15 @@ jobs:
         load: true
         context: .config
         file: .config/Dockerfile
-        build-args: |
-          USER=${{ github.actor }}
-          GROUP=${{ github.actor }}
-          BRANCH=${{ github.head_ref }}
-          TZ=${{ env.TZ }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          USER=${{ github.actor }}
+          GROUP=${{ github.actor }}
+          BRANCH=${{ env.BRANCH }}
+          TZ=${{ env.TZ }}
     - name: Scan your Docker container image for vulnerabilities
       uses: aquasecurity/trivy-action@master
       continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ env:
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 defaults:
   run:
@@ -54,9 +54,17 @@ jobs:
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            USER=${{ github.actor }}
+            GROUP=${{ github.actor }}
+            TZ=${{ env.TZ }}
 
   ghcr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - uses: docker/setup-buildx-action@v2
@@ -73,7 +81,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GH_TOKEN }}
     - name: Push to ghcr
       uses: docker/build-push-action@v4
       with:
@@ -84,3 +92,7 @@ jobs:
         cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          USER=${{ github.actor }}
+          GROUP=${{ github.actor }}
+          TZ=${{ env.TZ }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ defaults:
     shell: bash
 
 concurrency:
-  group: ${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:


### PR DESCRIPTION
Instead of GITHUB_TOKEN, which does not triggers events to prevent infinite loops.

More: semantic-release/semantic-release#1906