### PR TITLE
fix(install): Correct function name for setting perms on XDG_RUNTIME_DIR

### DIFF
--- a/install
+++ b/install
@@ -619,7 +619,7 @@ step_ensure_ownership() {
   for dir in "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_LOCAL_DIR" "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$XDG_DESKTOP_DIR" "$XDG_DOWNLOAD_DIR" "$XDG_DOCUMENTS_DIR" "$XDG_MUSIC_DIR" "$XDG_PICTURES_DIR" "$XDG_VIDEOS_DIR" "$XDG_PROJECTS_DIR" "$XDG_WORKSPACE_DIR" "$XDG_RUNTIME_DIR"; do
     setup_dir "$dir" "XDG/CHOWN/$dir"
   done
-  set_permission "$XDG_RUNTIME_DIR" "XDG/CHMOD/$XDG_RUNTIME_DIR" 700
+  set_permissions "$XDG_RUNTIME_DIR" "XDG/CHMOD/$XDG_RUNTIME_DIR" 700
   s "[XDG] Completed ✔︎"
 
   if [[ "$*" =~ '--zsh' ]]; then


### PR DESCRIPTION
Updated the function name from `set_permission` to `set_permissions` for consistency and clarity in the installation script.