### PR TITLE
ref(install): Simplify USERNAME and GROUPNAME assignment logic

### DIFF
--- a/install
+++ b/install
@@ -8,7 +8,7 @@ set -eu
 
 # GLOBALS and CONSTANTS
 declare -g -A COLORS=([E]='\033[0;31m' [F]='\033[0;31m' [S]='\033[0;32m' [W]='\033[1;33m' [I]='\033[0;34m' [MAGENTA]='\033[0;35m' [NC]='\033[0m')
-declare -g USERNAME="roalcantara" GROUPNAME="staff" TIMEZONE="America/Sao_Paulo" REPO_URL="https://github.com/roalcantara/dots" BRANCH="main" USR_LOCAL_BIN="/usr/local/bin" PACKAGE_MANAGER="flox" FLOX_VERSION="1.7.2" CONFIGS_TO_BACKUP=".bashrc .bash_logout .bash_profile .profile .zshrc .zprofile .gitconfig .oh-my-zsh"
+declare -g USERNAME GROUPNAME TIMEZONE="America/Sao_Paulo" REPO_URL="https://github.com/roalcantara/dots" BRANCH="main" USR_LOCAL_BIN="/usr/local/bin" PACKAGE_MANAGER="flox" FLOX_VERSION="1.7.2" CONFIGS_TO_BACKUP=".bashrc .bash_logout .bash_profile .profile .zshrc .zprofile .gitconfig .oh-my-zsh"
 declare -g UNAME ARCH PLATFORM_ARCH DISTRO ENV CONTEXT HOME DOTS_SRC_DIR FLOX_PATH BACKUP_DIR
 declare -g -A PACKAGES=(
   [mise]="node@22.17 python ripgrep bat delta eza fd fzf starship zoxide gum pre-commit tree-sitter neovim age sops"
@@ -57,7 +57,8 @@ backup() {
     run_cmd ln -sf "$source" "$target"
   fi
 }
-group_exists() { [ "$UNAME" = "darwin" ] && dscl . -read /Groups/"$1" &>/dev/null || getent group "$1" &>/dev/null; }
+is_darwin() { [ "$UNAME" = "darwin" ]; }
+group_exists() { is_darwin && dscl . -read /Groups/"$1" &>/dev/null || getent group "$1" &>/dev/null; }
 user_exists() { id "$1" &>/dev/null; }
 show_usage() {
   echo "Usage: $0 [options]" >&2
@@ -289,6 +290,20 @@ prepare_argument_parsing() {
       ;;
     esac
   done
+  if [[ -z "$USERNAME" ]] || [[ "$USER" != "root" ]]; then
+    USERNAME=$USER
+  else
+    USERNAME="roalcantara"
+  fi
+  if [[ -z "$GROUPNAME" ]] || [[ "$USER" != "root" ]]; then
+    GROUPNAME=$(id -gn)
+  else
+    if is_darwin; then
+      GROUPNAME="staff"
+    else
+      GROUPNAME="wheel"
+    fi
+  fi
   [[ "$PACKAGE_MANAGER" != "flox" && "$PACKAGE_MANAGER" != "mise" ]] && show_usage && exit 1
   success "$step Arguments extraction READY => [USERNAME:$USERNAME, GROUPNAME:$GROUPNAME, TIMEZONE:$TIMEZONE, PACKAGE_MANAGER:$PACKAGE_MANAGER, REPO_URL:$REPO_URL, BRANCH:$BRANCH] ✔"
 }


### PR DESCRIPTION
Updated the installation script to dynamically assign USERNAME and GROUPNAME based on the current user context. This change enhances flexibility and ensures proper group assignment across different operating systems, particularly for non-root users.