### PR TITLE
fix(install): Use sudo for package manager commands

### DIFF
--- a/install
+++ b/install
@@ -136,24 +136,16 @@ fix_flox_permissions() {
   fi
 }
 package_manager_install_flox() {
-  local cmd_prefix=""
-  if is_container || is_devcontainer; then
-    cmd_prefix="sudo "
-  fi
   if is_darwin; then # curl -L https://downloads.flox.dev/by-env/stable/deb/flox-1.7.4.aarch64-darwin.pkg -o /tmp/flox.pkg && sudo installer -pkg /tmp/flox.pkg -target / && rm -f /tmp/flox.pkg && flox --version | wget https://downloads.flox.dev/by-env/stable/osx/flox-1.7.2.aarch64-darwin.pkg -O /tmp/flox.pkg && sudo installer -pkg /tmp/flox.pkg -target / && rm -f /tmp/flox.pkg && flox --version
     run_cmd wget "https://downloads.flox.dev/by-env/stable/osx/flox-${FLOX_VERSION}.${PLATFORM_ARCH}-darwin.pkg" -O "/tmp/flox.pkg"
-    run_cmd ${cmd_prefix}installer -pkg /tmp/flox.pkg -target / && rm -f /tmp/flox.pkg
+    run_cmd sudo installer -pkg /tmp/flox.pkg -target / && rm -f /tmp/flox.pkg
   else # curl -L https://downloads.flox.dev/by-env/stable/deb/flox-1.7.4.aarch64-linux.deb -o /tmp/flox.deb && sudo dpkg -i /tmp/flox.deb && rm /tmp/flox.deb && flox --version | wget https://downloads.flox.dev/by-env/stable/deb/flox-1.7.2.aarch64-linux.deb -O /tmp/flox.deb && sudo dpkg -i /tmp/flox.deb && rm /tmp/flox.deb && flox --version
     run_cmd wget "https://downloads.flox.dev/by-env/stable/deb/flox-${FLOX_VERSION}.${PLATFORM_ARCH}-linux.deb" -O "/tmp/flox.deb"
-    run_cmd ${cmd_prefix}dpkg -i /tmp/flox.deb && rm -f /tmp/flox.deb
+    run_cmd sudo dpkg -i /tmp/flox.deb && rm -f /tmp/flox.deb
   fi
 }
 packages_install_flox() {
-  local cmd_prefix=""
-  if is_container || is_devcontainer; then
-    cmd_prefix="sudo "
-  fi
-  run_cmd ${cmd_prefix}flox pull roalcantara/default --dir "$HOME" --force
+  run_cmd sudo flox pull roalcantara/default --dir "$HOME" --force
   # Fix permissions after installation for container/devcontainer use
   fix_flox_permissions
   eval "$(FLOX_SHELL=/bin/bash flox activate --dir $HOME)"


### PR DESCRIPTION
Ensure that the installation commands for Flox use sudo to avoid permission issues during installation on both Darwin and Linux platforms. This change simplifies the command structure by removing unnecessary conditional checks for container environments.