### PR TITLE
fix(zsh): Update zimfw installation condition to check for .zimrc exi…

### DIFF
--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -297,7 +297,7 @@
 # }
 
 # ZIM | https://zimfw.sh {
-  if [[ ! -e $ZDOTDIR/.zimrc ]]; then
+  if [[ -e $ZDOTDIR/.zimrc ]]; then
     # The Zsh configuration framework with blazing speed and modular extensions.
     if [[ ! -e $ZIM_HOME/zimfw.zsh ]]; then   # Download zimfw plugin manager if missing QUIETLY
       mkdir -p $ZIM_HOME && wget -q -O $ZIM_HOME/zimfw.zsh https://github.com/zimfw/zimfw/releases/latest/download/zimfw.zsh

--- a/install
+++ b/install
@@ -239,7 +239,11 @@ task_add_flox() {
   fi
 }
 task_add_packages_from_flox() {
-  run_cmd sudo flox pull roalcantara/cockpit --dir "$HOME" --force
+  if is_host; then
+    run_cmd sudo flox pull roalcantara/default --dir "$HOME" --force
+  else
+    run_cmd sudo flox pull roalcantara/cockpit --dir "$HOME" --force
+  fi
   # Fix permissions after installation for container/devcontainer use
   task_add_flox_permissions
   eval "$(FLOX_SHELL=/bin/bash flox activate --dir $HOME)"


### PR DESCRIPTION
…stence

Modified the Zsh configuration to ensure that the zimfw plugin manager is only downloaded if the .zimrc file already exists. This change prevents unnecessary installations and streamlines the setup process for users.