### PR TITLE
fix(ci/publish): Add security option for Docker build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,3 +91,4 @@ jobs:
             type=registry,ref=docker.io/${{ env.REGISTRY_IMAGE }}-cache:${{ matrix.distro }},mode=max
           github-token: ${{ secrets.GH_TOKEN }}
           secrets: github_token=${{ secrets.GH_TOKEN }}
+          build-opts: --security-opt=seccomp=unconfined

--- a/config/vscode/settings.json
+++ b/config/vscode/settings.json
@@ -1593,5 +1593,6 @@
     "https://json-schema.org/": true,
     "https://developer.microsoft.com/json-schemas/": true,
     "https://biomejs.dev": true
-  }
+  },
+  "mise.binPath": "/Users/roalcantara/.local/bin/mise"
 }


### PR DESCRIPTION
This pull request, titled **"fix(ci/publish): Add security option for Docker build"**, introduces a tweak in the CI publish workflow. It adds the `--security-opt=seccomp=unconfined` option to the Docker build step, aiming to enhance the security settings during the build process. Further details regarding security options are referenced in the [Docker documentation](https://docs.docker.com/engine/security/seccomp/).

The PR targets the `main` branch and is authored by the repository owner, **@roalcantara**, who is also the assignee. It modifies 2 files, with 3 additions and 1 deletion. The changes are marked as addressing both a **bug** and an **enhancement**, as per the included labels.

The pull request has not been merged yet but is currently in an "unstable" mergeable state.

More: https://docs.docker.com/engine/security/seccomp/