### PR TITLE
refactor(install): Update configuration paths and symlink logic

### DIFF
--- a/config/kodexb/sources/macos.yml
+++ b/config/kodexb/sources/macos.yml
@@ -65,6 +65,13 @@ commands:
     desc: Link openjdk to /Library/Java/JavaVirtualMachines
     tags: [maven, springboot, java, jdk, openjdk]
 
+  dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2}':
+    desc: Check the user's shell (as used by the current login session)
+    tags: [macos, user, shell]
+  dscl . -read /Groups/"wheel" &>/dev/null:
+    desc: Check if the wheel group exists
+    tags: [macos, user, group]
+
   ### defaults | macOS user preferences system
   defaults help:
     desc: Show help for defaults

--- a/config/zsh/.zprofile
+++ b/config/zsh/.zprofile
@@ -17,12 +17,12 @@
 
 # MISE | https://mise.jdx.dev {
   # A polyglot tool version manager. It replaces tools like asdf, nvm, pyenv, rbenv, etc.
-  # Set the global configuration directory path
-  export MISE_GLOBAL_CONFIG_DIR=${MISE_GLOBAL_CONFIG_DIR:-$XDG_DATA_HOME/mise}
   # Set the global configuration file path
-  export MISE_GLOBAL_CONFIG_FILE=${MISE_GLOBAL_CONFIG_FILE:-$MISE_GLOBAL_CONFIG_DIR/config.toml}
+  export MISE_GLOBAL_CONFIG_FILE=${MISE_GLOBAL_CONFIG_FILE:-$XDG_CONFIG_HOME/mise/config.toml}
   # Set the cache directory path
   export MISE_CACHE_DIR=${MISE_CACHE_DIR:-$XDG_CACHE_HOME/mise}
+  # Set the data directory path
+  export MISE_DATA_HOME=${MISE_DATA_HOME:-$XDG_DATA_HOME/mise}
 # }
 
 # STARSHIP | https://starship.rs | https://starship.rs/config/#configuration {

--- a/distros/debian/container-structure-test.yml
+++ b/distros/debian/container-structure-test.yml
@@ -21,12 +21,12 @@ globalEnvVars:
     value: /home/vscode/.config/zsh
   - key: ZIM_HOME
     value: /home/vscode/.local/state/zim
-  - key: MISE_GLOBAL_CONFIG_DIR
+  - key: MISE_DATA_HOME
     value: /home/vscode/.local/share/mise
-  - key: MISE_GLOBAL_CONFIG_FILE
-    value: /home/vscode/.local/share/mise/config.toml
   - key: MISE_CACHE_DIR
     value: /home/vscode/.cache/mise
+  - key: MISE_GLOBAL_CONFIG_FILE
+    value: /home/vscode/.config/mise/config.toml
   - key: NPM_CONFIG_USERCONFIG
     value: /home/vscode/.config/npm/.npmrc
   - key: NPM_CONFIG_PREFIX
@@ -70,7 +70,34 @@ commandTests:
   - name: Flox cockpit environment should have all minimum tools installed
     command: flox
     args: [list, --dir=/home/vscode, --name]
-    expectedOutput: ['age', 'bat', 'coreutils', 'delta', 'eza', 'fd', 'findutils', 'fzf', 'gawk', 'gitlint', 'glow', 'gnugrep', 'gnumake', 'gum', 'less', 'lesspipe', 'mise', 'neovim', 'pre-commit', 'ripgrep', 'sops', 'sqlite', 'starship', 'tree-sitter', 'zoxide']
+    expectedOutput:
+      [
+        'age',
+        'bat',
+        'coreutils',
+        'delta',
+        'eza',
+        'fd',
+        'findutils',
+        'fzf',
+        'gawk',
+        'gitlint',
+        'glow',
+        'gnugrep',
+        'gnumake',
+        'gum',
+        'less',
+        'lesspipe',
+        'mise',
+        'neovim',
+        'pre-commit',
+        'ripgrep',
+        'sops',
+        'sqlite',
+        'starship',
+        'tree-sitter',
+        'zoxide',
+      ]
 
 # HOME DIRECTORIES
 fileExistenceTests:

--- a/distros/ubuntu/container-structure-test.yml
+++ b/distros/ubuntu/container-structure-test.yml
@@ -21,12 +21,12 @@ globalEnvVars:
     value: /home/vscode/.config/zsh
   - key: ZIM_HOME
     value: /home/vscode/.local/state/zim
-  - key: MISE_GLOBAL_CONFIG_DIR
+  - key: MISE_DATA_HOME
     value: /home/vscode/.local/share/mise
-  - key: MISE_GLOBAL_CONFIG_FILE
-    value: /home/vscode/.local/share/mise/config.toml
   - key: MISE_CACHE_DIR
     value: /home/vscode/.cache/mise
+  - key: MISE_GLOBAL_CONFIG_FILE
+    value: /home/vscode/.config/mise/config.toml
   - key: NPM_CONFIG_USERCONFIG
     value: /home/vscode/.config/npm/.npmrc
   - key: NPM_CONFIG_PREFIX
@@ -70,7 +70,34 @@ commandTests:
   - name: Flox cockpit environment should have all minimum tools installed
     command: flox
     args: [list, --dir=/home/vscode, --name]
-    expectedOutput: ['age', 'bat', 'coreutils', 'delta', 'eza', 'fd', 'findutils', 'fzf', 'gawk', 'gitlint', 'glow', 'gnugrep', 'gnumake', 'gum', 'less', 'lesspipe', 'mise', 'neovim', 'pre-commit', 'ripgrep', 'sops', 'sqlite', 'starship', 'tree-sitter', 'zoxide']
+    expectedOutput:
+      [
+        'age',
+        'bat',
+        'coreutils',
+        'delta',
+        'eza',
+        'fd',
+        'findutils',
+        'fzf',
+        'gawk',
+        'gitlint',
+        'glow',
+        'gnugrep',
+        'gnumake',
+        'gum',
+        'less',
+        'lesspipe',
+        'mise',
+        'neovim',
+        'pre-commit',
+        'ripgrep',
+        'sops',
+        'sqlite',
+        'starship',
+        'tree-sitter',
+        'zoxide',
+      ]
 
 # HOME DIRECTORIES
 fileExistenceTests:
@@ -149,7 +176,7 @@ fileExistenceTests:
   - name: ~/.config/nvim/.venv/bin/python3 file
     path: /home/vscode/.config/nvim/.venv/bin/python3
     shouldExist: true
-    permissions: Lrwxrwxrwx    
+    permissions: Lrwxrwxrwx
   - name: ~/.config/zsh dir (ZDOTDIR)
     path: /home/vscode/.config/zsh
     shouldExist: true

--- a/install
+++ b/install
@@ -84,7 +84,7 @@ run_as_user() {
       XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-}" \
       XDG_DATA_HOME="${XDG_DATA_HOME:-}" \
       MISE_DATA_HOME="${MISE_DATA_HOME:-}" \
-      MISE_GLOBAL_CONFIG_DIR="${MISE_GLOBAL_CONFIG_DIR:-}" \
+      MISE_CACHE_DIR="${MISE_CACHE_DIR:-}" \
       FLOX_PATH="${FLOX_PATH:-}" \
       GITHUB_TOKEN="${GITHUB_TOKEN:-}" \
       USR_LOCAL_BIN="${USR_LOCAL_BIN:-}" \
@@ -664,8 +664,8 @@ prepare_home_and_xdg_dirs() {
     "$HOME/.local/share/npm:NPM_CONFIG_PREFIX" \
     "$HOME/.local/share/gems:GEM_HOME" \
     "$HOME/.local/share/mise:MISE_DATA_HOME" \
-    "$HOME/.local/share/mise:MISE_GLOBAL_CONFIG_DIR"
-  ok "$1" "HOME/XDG/DIRS" "{HOME=$HOME, XDG_CONFIG_HOME=$XDG_CONFIG_HOME, XDG_CACHE_HOME=$XDG_CACHE_HOME, XDG_DATA_HOME=$XDG_DATA_HOME, XDG_STATE_HOME=$XDG_STATE_HOME, ZSH_CACHE_DIR=$ZSH_CACHE_DIR, NPM_CONFIG_PREFIX=$NPM_CONFIG_PREFIX, GEM_HOME=$GEM_HOME, MISE_DATA_HOME=$MISE_DATA_HOME, MISE_GLOBAL_CONFIG_DIR=$MISE_GLOBAL_CONFIG_DIR} exported!" "✔"
+    "$HOME/.cache/mise:MISE_CACHE_DIR"
+  ok "$1" "HOME/XDG/DIRS" "{HOME=$HOME, XDG_CONFIG_HOME=$XDG_CONFIG_HOME, XDG_CACHE_HOME=$XDG_CACHE_HOME, XDG_DATA_HOME=$XDG_DATA_HOME, XDG_STATE_HOME=$XDG_STATE_HOME, ZSH_CACHE_DIR=$ZSH_CACHE_DIR, NPM_CONFIG_PREFIX=$NPM_CONFIG_PREFIX, GEM_HOME=$GEM_HOME, MISE_DATA_HOME=$MISE_DATA_HOME, MISE_CACHE_DIR=$MISE_CACHE_DIR} exported!" "✔"
 }
 prepare_tools_zsh() {
   local zsh_path="$(command -v zsh)"
@@ -733,10 +733,16 @@ setup_user_home_and_dotfiles() {
   # Create symlinks in $HOME/.local/bin for each file in $HOME/.local/share/dots/config/bin if not already present
   if [ -d "$HOME/.local/share/dots/config/bin" ]; then
     for file in "$HOME/.local/share/dots/config/bin/"*; do
+      # Only expose executable regular files as commands in ~/.local/bin.
+      [ -f "$file" ] && [ -x "$file" ] || continue
       local base_name="$(basename "$file")"
-      if [ -f "$file" && ! -L "$HOME/.local/bin/$base_name" ]; then
-        run_cmd ${cmd_prefix}ln -sf "$file" "$HOME/.local/bin/$base_name"
-        ok "$1" "USER/HOME/DOTS/BIN" "Symlink created for '$base_name'! ✔"
+      local current_target="$HOME/.local/bin/$base_name"
+      if has_cmd readlink && [ -L "$HOME/.local/bin/$base_name" ]; then
+        current_target="$(readlink "$HOME/.local/bin/$base_name" || true)"
+      fi
+      if [ ! -L "$HOME/.local/bin/$base_name" ] || [ "$current_target" != "$file" ]; then
+        run_cmd ${cmd_prefix}ln -snf "$file" "$HOME/.local/bin/$base_name"
+        ok "$1" "USER/HOME/DOTS/BIN" "Symlink set '$HOME/.local/bin/$base_name' targeting => '$file'! ✔"
       fi
     done
   fi


### PR DESCRIPTION
- Replaced MISE_GLOBAL_CONFIG_DIR with MISE_CACHE_DIR in the install script.
- Adjusted symlink creation logic to ensure correct target resolution.
- Updated .zprofile to reflect new directory structure for MISE configuration and data paths.
- Modified container structure test configurations for Debian and Ubuntu to align with new MISE paths.