### PR TITLE
Organize settings and enhance git functions; update skills and version

### DIFF
--- a/config/cursor/skills/ears/SKILL.md
+++ b/config/cursor/skills/ears/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: ears
+description: >
+  Same scope as skill "sdd": exactly three files under docs/specs/<feature-slug>/
+  (requirements.md, design.md, tasks.md) with EARS, normative design contract,
+  and ordered verification tasks. MUST match docs/example/{requirements,design,
+  tasks}.md layout when present. Design must use concrete values only (no "pick
+  one", "either", or pre-verification placeholders). Cross-links via Markdown
+  headings for stable fragments. **All generated prose in Brazilian Portuguese
+  (pt-BR).** Code identifiers stay English. Use when the user wants specs in
+  pt-BR or asks for EARS / SDD / PRD / requisitos in Portuguese.
+compatibility: Designed for Cursor Agent and similar agentic coding tools.
+metadata:
+  author: roalcantara
+  version: "1.1"
+---
+
+# Gerador de Feature Spec (estilo Kiro)
+
+Gere uma spec completa com três arquivos para a feature descrita, replicando
+o workflow de specs do Kiro. Leia [references/EARS.md](references/EARS.md)
+antes de escrever qualquer requisito. Leia
+[references/FORMATS.md](references/FORMATS.md) antes de criar qualquer arquivo.
+
+**Todos os artefatos gerados devem estar em português brasileiro (pt-BR).**
+Isso inclui textos, comentários, exemplos, mensagens de erro e rótulos em diagramas.
+Nomes de variáveis, tipos, campos JSON e código permanecem em inglês quando for
+convenção da stack.
+
+## Inegociáveis (layout, papéis, links)
+
+1. **Fonte da verdade do layout**
+   - Se o workspace tiver **`docs/example/requirements.md`**, **`docs/example/design.md`** e **`docs/example/tasks.md`**, trate-os como **esqueleto canônico**: **mesma ordem de seções**, **mesmos níveis de heading** (`#`, `##`, `###`, `####`) e **mesmos padrões** (tabelas vs listas) desses arquivos. Preencha o conteúdo para `<feature-slug>` em **pt-BR**; **não** troque o outline pelo template curto do FORMATS sozinho.
+   - Se esses arquivos **não existirem**, use apenas os templates em [references/FORMATS.md](references/FORMATS.md).
+
+2. **Separação de papéis**
+   - **`requirements.md`**: *o quê* deve valer e *como saber* (critérios EARS em pt-BR). **Referencie** o design com links (`design.md#slug-do-heading`). **Não** duplique tabelas normativas longas (códigos HTTP, matriz de rotas, schemas JSON) se já estiverem no `design.md`.
+   - **`design.md`**: *como* em detalhe **fechado** e **verificável** — rotas, métodos, corpos, status HTTP, formato de erro, filas, retries, DLQ, etc. **Fonte única da verdade** para esses fatos (texto em pt-BR; nomes técnicos podem ser em inglês).
+   - **`tasks.md`**: *ordem de trabalho* e passos de verificação que **apontam** para ids de requisito **e** headings do design; **não** recoloque o contrato inteiro no meio da tarefa.
+
+3. **Âncoras e links cruzados**
+   - Defina alvos de link com **headings Markdown** reais (`#### 8.1 Tabela de rotas`, etc.). **Não** dependa só de `<a id="...">` para preview no Cursor/VS Code.
+   - Links de `requirements` ou `tasks` para o design devem usar o **fragmento** gerado a partir do texto do heading (slug estilo GitHub).
+
+4. **Proibido em trechos normativos do design** (tudo que um verificador compara a um valor esperado)
+   - Frases como: "escolha uma", "o design decide depois", "antes da verificação preencha", "X ou Y" para o mesmo caso, `_ex.: 200_` **no lugar** de um valor fixo em tabela canônica, "PUT ou PATCH" quando só um método vale.
+   - Se faltar decisão, **pergunte ao usuário** antes de escrever a subseção — **não** deixe opções abertas no documento entregue.
+
+---
+
+## Passo 0 — Seleção do Workflow
+
+Pergunte ao usuário:
+
+> "Qual workflow você quer usar?
+> - **Requirements-First** — você sabe o comportamento desejado; a arquitetura
+>   vai se adaptar para atendê-lo.
+> - **Design-First (Alto Nível)** — você tem uma arquitetura em mente;
+>   os requisitos serão derivados dela.
+> - **Design-First (Baixo Nível)** — você tem pseudocódigo, interfaces ou
+>   algoritmos em mente; os requisitos serão derivados deles."
+
+Aguarde a seleção explícita antes de continuar.
+
+Derive o `<feature-slug>` a partir do nome da feature (minúsculas, apenas hífens).
+Todos os arquivos vão para `docs/specs/<feature-slug>/`.
+
+---
+
+## Workflow A — Requirements-First
+
+**Fluxo:** Requisitos → Design → Tarefas
+
+### Fase 1 — Requisitos
+
+1. Faça perguntas de clarificação se a descrição da feature for ambígua:
+   - Quem são os usuários / papéis envolvidos?
+   - Quais são os cenários de sucesso principais?
+   - Quais são os casos de erro e edge cases relevantes?
+   - Há restrições não-funcionais (performance, segurança, compliance)?
+
+2. Gere `docs/specs/<feature-slug>/requirements.md` seguindo
+   [references/FORMATS.md](references/FORMATS.md#requirementsmd) **e**, quando
+   existir, a **ordem de seções e headings** de `docs/example/requirements.md`
+   (conteúdo em **pt-BR**).
+
+3. Regras para requisitos:
+   - Escreva cada critério de aceitação em formato EARS (veja [references/EARS.md](references/EARS.md))
+   - Use `QUANDO … O SISTEMA DEVE …` como padrão principal
+   - Numere cada critério dentro da sua história (1.1, 1.2, 2.1, …)
+   - Cubra caminho feliz, edge cases e tratamento de erros
+
+4. **PARE. Mostre o arquivo e pergunte:**
+   > "Aqui está o `requirements.md`. Isso captura tudo corretamente?
+   > Me diga o que ajustar antes de eu seguir para o design."
+
+   Aguarde aprovação explícita ("ok", "aprovado", "pode continuar", etc.)
+   antes de prosseguir.
+
+### Fase 2 — Design
+
+1. Gere `docs/specs/<feature-slug>/design.md` seguindo
+   [references/FORMATS.md](references/FORMATS.md#designmd) **e**, quando existir,
+   a **ordem de seções e headings** de `docs/example/design.md` (pt-BR).
+
+2. Toda decisão arquitetural deve referenciar ao menos um número de requisito
+   do `requirements.md`.
+
+3. **Contrato normativo**: toda API, payload, código de status ou política que um
+   testador possa asserir DEVE aparecer **uma vez**, de forma **concreta**, neste
+   arquivo (veja **Inegociáveis**). Sem linhas placeholder ou escolhas adiadas.
+
+4. Inclua um diagrama de sequência Mermaid para o fluxo principal (salvo se o
+   exemplo canônico omitir para esse tipo de feature — nesse caso, siga o exemplo).
+
+5. **PARE. Mostre o arquivo e pergunte:**
+   > "Aqui está o `design.md`. A arquitetura está correta?
+   > Alguma mudança antes de eu gerar as tarefas?"
+
+   Aguarde aprovação explícita antes de prosseguir.
+
+### Fase 3 — Tarefas
+
+1. Gere `docs/specs/<feature-slug>/tasks.md` seguindo
+   [references/FORMATS.md](references/FORMATS.md#tasksmd) **e**, quando existir,
+   a **ordem de seções e headings** de `docs/example/tasks.md` (pt-BR).
+
+2. Regras para tarefas:
+   - Cada tarefa deve referenciar o(s) número(s) de requisito que satisfaz
+   - Ordene por dependência (nenhuma tarefa deve depender de uma não-resolvida acima dela)
+   - Inclua tarefas de setup, implementação e validação
+   - Bullets de verificação devem citar **`design.md#slug-do-heading`** (e o
+     `requirements.md` quando fizer sentido) em vez de recolar JSON ou tabelas de status inteiros
+
+3. **PARE. Mostre o arquivo e pergunte:**
+   > "Aqui está o `tasks.md`. Podemos começar a implementação,
+   > ou você quer ajustar algo?"
+
+---
+
+## Workflow B — Design-First
+
+**Fluxo:** Design → Requisitos → Tarefas
+
+### Fase 1 — Design
+
+1. Faça perguntas de clarificação se necessário:
+   - Quais são as restrições técnicas ou stack obrigatório?
+   - Há requisitos não-funcionais (latência, throughput, compliance)?
+   - Existem diagramas ou documentos de arquitetura para incorporar?
+   - Alto Nível (componentes, interações) ou Baixo Nível (pseudocódigo,
+     interfaces)?
+
+2. Gere `docs/specs/<feature-slug>/design.md` seguindo
+   [references/FORMATS.md](references/FORMATS.md#designmd) e, quando existir,
+   o layout de **`docs/example/design.md`**. Aplique os **Inegociáveis**: valores
+   técnicos **já fechados** (sem tabelas "TBD").
+
+3. Inclua explicitamente todas as restrições e requisitos não-funcionais.
+
+4. **PARE. Mostre o arquivo e pergunte:**
+   > "Aqui está o `design.md`. A arquitetura corresponde ao que você tinha
+   > em mente? Itere aqui antes de eu derivar os requisitos."
+
+   Aguarde aprovação explícita antes de prosseguir.
+
+### Fase 2 — Requisitos
+
+1. Derive os requisitos a partir do design confirmado.
+
+2. Gere `docs/specs/<feature-slug>/requirements.md` seguindo
+   [references/FORMATS.md](references/FORMATS.md#requirementsmd) e, quando
+   existir, o layout de **`docs/example/requirements.md`**.
+
+3. Os requisitos devem ser viáveis dado o design confirmado — não adicione
+   comportamentos que o design não suporta.
+
+4. Escreva cada critério de aceitação em formato EARS (veja [references/EARS.md](references/EARS.md)).
+
+5. **PARE. Mostre o arquivo e pergunte:**
+   > "Aqui está o `requirements.md` derivado do seu design. Isso reflete
+   > todos os comportamentos esperados? Alguma lacuna antes de eu gerar as tarefas?"
+
+   Aguarde aprovação explícita antes de prosseguir.
+
+### Fase 3 — Tarefas
+
+Idêntico ao Workflow A, Fase 3.
+
+---
+
+## Regras Gerais
+
+- Nunca pule uma fase nem prossiga sem aprovação explícita do usuário.
+- Nunca gere os três arquivos de uma vez.
+- Se o usuário pedir alterações após a aprovação, atualize o arquivo,
+  mostre o diff e reconfirme antes de continuar.
+- Prefira descrições de tarefas curtas e sem ambiguidade.
+- Todos os diagramas Mermaid devem ser válidos e renderizáveis.
+- **Layout**: não "melhore" nem reorganize a estrutura do exemplo canônico sem
+  pedido explícito do usuário; consistência entre features pesa mais que um outline
+  preferido pelo agente.
+- **Design alinhado**: se o requisito disser "conforme design §…" ou linkar uma
+  subseção, essa subseção DEVE existir e conter **um** valor claro por decisão.

--- a/config/cursor/skills/ears/assets/examples/design-first/design.md
+++ b/config/cursor/skills/ears/assets/examples/design-first/design.md
@@ -1,0 +1,106 @@
+# Design: Middleware de Rate Limiting
+
+## Visão Geral
+
+Rate limiter com algoritmo de token bucket implementado como middleware Express,
+usando Redis para estado distribuído. Os limites são configuráveis por endpoint
+e aplicados por ID de usuário (autenticado) ou endereço IP (não autenticado).
+
+## Arquitetura
+
+### Componentes
+
+| Componente | Responsabilidade |
+|---|---|
+| `rateLimiter()` | Factory do middleware Express — envolve qualquer rota com rate limiting |
+| `TokenBucket` | Algoritmo central — gerencia reabastecimento e consumo de tokens |
+| `RedisStore` | Backend de estado distribuído — persiste o estado do bucket entre instâncias |
+| `LimitConfig` | Configuração por endpoint — capacidade, taxa de reabastecimento, janela |
+
+### Diagrama de Sequência
+
+```mermaid
+sequenceDiagram
+    actor Cliente
+    participant Express
+    participant RateLimiter
+    participant TokenBucket
+    participant Redis
+
+    Cliente->>Express: requisição HTTP
+    Express->>RateLimiter: middleware(req, res, next)
+    RateLimiter->>RateLimiter: resolverChave(req) — userId ou IP
+    RateLimiter->>Redis: GET bucket:{chave}
+    Redis-->>RateLimiter: estado do bucket | null
+    RateLimiter->>TokenBucket: consumir(estado, config)
+    TokenBucket->>TokenBucket: reabastecer tokens desde a última requisição
+    TokenBucket->>TokenBucket: verificar se há token disponível
+    TokenBucket-->>RateLimiter: { permitido, restantes, resetEm }
+    RateLimiter->>Redis: SET bucket:{chave} novoEstado EX ttl
+    alt permitido
+        RateLimiter->>Express: next()
+        Express-->>Cliente: resposta 200
+    else limite atingido
+        RateLimiter-->>Cliente: 429 Too Many Requests
+    end
+```
+
+## Modelos de Dados
+
+```typescript
+interface BucketState {
+  tokens: number         // quantidade atual de tokens
+  lastRefillAt: number   // timestamp unix em ms
+}
+
+interface LimitConfig {
+  capacity: number       // máximo de tokens (teto de burst)
+  refillRate: number     // tokens adicionados por segundo
+  windowMs: number       // TTL do Redis para a chave do bucket
+}
+
+interface LimitResult {
+  allowed: boolean
+  remaining: number
+  resetAt: number        // timestamp unix em ms quando o bucket estará cheio novamente
+}
+```
+
+**Algoritmo token bucket (pseudocódigo):**
+
+```
+função consumir(estado, config):
+  agora = Date.now()
+  decorrido = agora - estado.lastRefillAt
+  reabastecido = piso(decorrido / 1000 * config.refillRate)
+  tokens = min(estado.tokens + reabastecido, config.capacity)
+
+  se tokens >= 1:
+    retornar { permitido: true, tokens: tokens - 1, lastRefillAt: agora }
+  senão:
+    retornar { permitido: false, tokens: 0, lastRefillAt: agora }
+```
+
+## Tratamento de Erros
+
+| Cenário | Comportamento | Requisito |
+|---|---|---|
+| Falha na conexão com Redis | Fail-open — permite a requisição e registra aviso | 1.3 |
+| Token indisponível | 429 com header `Retry-After` | 1.1 |
+| Config ausente para a rota | Usa a config global padrão | 2.1 |
+
+## Considerações Não-Funcionais
+
+- **Latência:** GET + SET no Redis adiciona ~1ms por requisição em rede local.
+  Aceitável para a meta de menos de 100ms de overhead.
+- **Consistência distribuída:** Script Lua para GET + SET atômico no Redis,
+  evitando condições de corrida sob carga concorrente.
+- **Fail-open:** Se o Redis estiver inacessível, as requisições são liberadas
+  em vez de rejeitadas — disponibilidade é priorizada sobre limitação estrita.
+
+## Estratégia de Testes
+
+- **Unitários:** `TokenBucket.consumir()` — cálculo de reabastecimento, teto de burst, exaustão.
+- **Unitários:** `resolverChave()` — caminho autenticado vs. não autenticado.
+- **Integração:** Middleware aplicado a um app Express de teste com Redis via `ioredis-mock`.
+- **Carga:** Verificar overhead menor que 100ms a 1.000 req/s com `autocannon`.

--- a/config/cursor/skills/ears/assets/examples/design-first/requirements.md
+++ b/config/cursor/skills/ears/assets/examples/design-first/requirements.md
@@ -1,0 +1,58 @@
+# Requisitos: Middleware de Rate Limiting
+
+## Visão Geral
+
+Fornecer rate limiting configurável por endpoint para a API Express usando
+algoritmo de token bucket com Redis, aplicando limites por usuário ou IP.
+
+## Requisitos
+
+### 1. Limitação de Requisições
+
+**História:** Como operador da API, quero que as requisições sejam limitadas
+por endpoint, para que nenhum cliente consiga esgotar os recursos do servidor.
+
+#### Critérios de Aceitação
+
+1. QUANDO um cliente exceder o limite configurado de requisições para um endpoint
+   O SISTEMA DEVE responder com HTTP 429 e um header `Retry-After` indicando
+   quando o cliente poderá tentar novamente.
+
+2. QUANDO um cliente estiver dentro do limite configurado de requisições
+   O SISTEMA DEVE deixar a requisição passar para o próximo middleware sem
+   adicionar mais de 100ms de latência.
+
+3. SE o Redis estiver inacessível
+   ENTÃO O SISTEMA DEVE permitir a requisição, registrar um aviso de alerta
+   e não bloquear o fluxo (comportamento fail-open).
+
+---
+
+### 2. Configuração
+
+**História:** Como desenvolvedor, quero configurar limites diferentes por
+endpoint, para que eu possa aplicar restrições mais rígidas em rotas sensíveis.
+
+#### Critérios de Aceitação
+
+1. QUANDO uma rota não tiver limite explícito configurado
+   O SISTEMA DEVE aplicar o limite padrão global.
+
+2. QUANDO uma rota tiver um limite explícito configurado
+   O SISTEMA DEVE aplicar esse limite no lugar do padrão global.
+
+---
+
+### 3. Identificação do Cliente
+
+**História:** Como operador da API, quero que os limites sejam aplicados por
+usuário em requisições autenticadas e por IP nas não autenticadas, para que
+os limites sejam distribuídos de forma justa.
+
+#### Critérios de Aceitação
+
+1. QUANDO uma requisição contiver um token de autenticação válido
+   O SISTEMA DEVE aplicar o rate limit contra o ID do usuário autenticado.
+
+2. QUANDO uma requisição não contiver token de autenticação
+   O SISTEMA DEVE aplicar o rate limit contra o endereço IP do cliente.

--- a/config/cursor/skills/ears/assets/examples/design-first/tasks.md
+++ b/config/cursor/skills/ears/assets/examples/design-first/tasks.md
@@ -1,0 +1,30 @@
+# Tarefas: Middleware de Rate Limiting
+
+- [ ] 1. Implementar algoritmo central do TokenBucket
+  - Criar `TokenBucket.consumir(estado, config)` com cálculo de reabastecimento
+  - Aplicar teto de burst (`min(tokens + reabastecido, capacidade)`)
+  - Retornar `{ permitido, restantes, resetEm }`
+  - **Requisitos:** 1.1, 1.2
+
+- [ ] 2. Implementar RedisStore com operações atômicas
+  - Usar script Lua para GET + SET atômico e evitar condições de corrida
+  - Definir TTL das chaves de bucket igual a `config.windowMs`
+  - Expor métodos `buscar(chave)` e `salvar(chave, estado, ttl)`
+  - **Requisitos:** 1.2, 1.3
+
+- [ ] 3. Implementar factory de middleware `rateLimiter()`
+  - Aceitar `LimitConfig` por rota; usar padrão global se ausente
+  - Resolver chave do cliente: ID do usuário autenticado ou IP
+  - Chamar `RedisStore.buscar()` → `TokenBucket.consumir()` → `RedisStore.salvar()`
+  - Se permitido: chamar `next()`
+  - Se negado: responder 429 com header `Retry-After`
+  - Se Redis falhar: registrar aviso e chamar `next()` (fail-open)
+  - **Requisitos:** 1.1, 1.2, 1.3, 2.1, 2.2, 3.1, 3.2
+
+- [ ] 4. Escrever testes
+  - Unitários: `TokenBucket.consumir()` — reabastecimento, teto, casos de exaustão
+  - Unitários: `resolverChave()` — caminho autenticado vs. não autenticado
+  - Integração: middleware em app Express de teste com `ioredis-mock`
+  - Integração: falha do Redis → comportamento fail-open
+  - Carga: verificar overhead menor que 100ms a 1.000 req/s com `autocannon`
+  - **Requisitos:** 1.1, 1.2, 1.3, 2.1, 2.2, 3.1, 3.2

--- a/config/cursor/skills/ears/assets/examples/requirements-first/design.md
+++ b/config/cursor/skills/ears/assets/examples/requirements-first/design.md
@@ -1,0 +1,99 @@
+# Design: Autenticação de Usuários
+
+## Visão Geral
+
+Autenticação baseada em JWT com hash de senha via bcrypt. A abordagem stateless
+foi escolhida para suportar escalabilidade horizontal sem necessidade de
+armazenamento compartilhado de sessão. A proteção contra força bruta é tratada
+na camada de aplicação com um contador de tentativas armazenado no Redis.
+
+## Arquitetura
+
+### Componentes
+
+| Componente | Responsabilidade |
+|---|---|
+| `AuthController` | Gerencia as rotas HTTP: cadastro, login, logout, redefinição de senha |
+| `AuthService` | Lógica de negócio: validação de credenciais, geração de tokens, controle de bloqueio |
+| `UserRepository` | Persiste e recupera registros de usuário no banco de dados |
+| `TokenService` | Emite e valida tokens JWT de acesso e tokens de redefinição |
+| `MailService` | Envia e-mails transacionais (redefinição de senha) |
+| `LockoutCache` | Armazenamento Redis para contagem de tentativas falhas (req. 2.2) |
+
+### Diagrama de Sequência
+
+```mermaid
+sequenceDiagram
+    actor Usuário
+    participant Frontend
+    participant AuthController
+    participant AuthService
+    participant UserRepository
+    participant TokenService
+
+    Usuário->>Frontend: envia formulário de login
+    Frontend->>AuthController: POST /auth/login
+    AuthController->>AuthService: validarCredenciais(email, senha)
+    AuthService->>UserRepository: buscarPorEmail(email)
+    UserRepository-->>AuthService: usuário | null
+    AuthService->>AuthService: verificarBloqueio(email)
+    AuthService->>AuthService: bcrypt.compare(senha, hash)
+    AuthService->>TokenService: emitirTokenDeAcesso(userId)
+    TokenService-->>AuthService: jwt
+    AuthService-->>AuthController: { token }
+    AuthController-->>Frontend: 200 { token }
+    Frontend-->>Usuário: redireciona para o painel
+```
+
+## Modelos de Dados
+
+```typescript
+interface User {
+  id: string           // UUID
+  email: string        // único, minúsculas
+  passwordHash: string // bcrypt, fator de custo 12
+  createdAt: Date
+  updatedAt: Date
+}
+
+interface ResetToken {
+  id: string
+  userId: string
+  token: string        // aleatório criptograficamente, 32 bytes hex
+  expiresAt: Date      // agora + 1 hora (req. 3.1)
+  usedAt: Date | null  // null até ser consumido (req. 3.3)
+}
+```
+
+## Tratamento de Erros
+
+| Cenário | Comportamento | Requisito |
+|---|---|---|
+| E-mail duplicado no cadastro | 409 + "E-mail já cadastrado" | 1.2 |
+| Formato de e-mail inválido | 422 + erro inline no campo | 1.3 |
+| Senha muito curta | 422 + erro inline no campo | 1.4 |
+| Credenciais inválidas no login | 401 + mensagem genérica | 2.3 |
+| 5ª tentativa de login falha | 423 + mensagem de bloqueio + TTL de 15 min no Redis | 2.2 |
+| E-mail não cadastrado na redefinição | 200 + mesma mensagem de cadastrado (proteção contra enumeração) | 3.2 |
+| Link de redefinição expirado ou usado | 410 + "Este link expirou" | 3.3 |
+| Requisição com token invalidado | 401 | 4.2 |
+
+## Considerações Não-Funcionais
+
+- **Segurança:** Senhas com hash bcrypt de fator 12. Tokens de redefinição são
+  valores aleatórios criptograficamente seguros de 32 bytes, armazenados com
+  hash no banco.
+- **Proteção contra força bruta:** Contador de tentativas falhas no Redis com
+  TTL de 15 minutos por e-mail (req. 2.2). Contador zerado após login bem-sucedido.
+- **Validade do token:** Tokens JWT de acesso expiram em 1 hora. Estratégia de
+  refresh token está fora do escopo desta spec.
+- **Enumeração de contas:** O fluxo de redefinição retorna respostas idênticas
+  para e-mails cadastrados e não cadastrados (req. 3.2).
+
+## Estratégia de Testes
+
+- **Unitários:** `AuthService` — validação de credenciais, lógica de bloqueio,
+  verificação de expiração de token.
+- **Integração:** Fluxo completo cadastro → login → logout contra banco de teste.
+  Redefinição de senha ponta a ponta com servidor de e-mail mock.
+- **E2E:** Caminho feliz de login e bloqueio por força bruta via interface.

--- a/config/cursor/skills/ears/assets/examples/requirements-first/requirements.md
+++ b/config/cursor/skills/ears/assets/examples/requirements-first/requirements.md
@@ -1,0 +1,88 @@
+# Requisitos: Autenticação de Usuários
+
+## Visão Geral
+
+Permitir que usuários se cadastrem, façam login, redefinam senhas esquecidas
+e se desconectem com segurança. O sistema deve prevenir ataques de força bruta
+e validar o formato do e-mail antes da criação da conta.
+
+## Requisitos
+
+### 1. Cadastro de Usuário
+
+**História:** Como novo usuário, quero criar uma conta com meu e-mail e senha,
+para que eu possa acessar a plataforma.
+
+#### Critérios de Aceitação
+
+1. QUANDO o usuário enviar um e-mail e senha válidos
+   O SISTEMA DEVE criar uma nova conta e redirecionar para o painel principal.
+
+2. QUANDO o usuário enviar um e-mail já cadastrado
+   O SISTEMA DEVE exibir "E-mail já cadastrado" e não criar uma conta duplicada.
+
+3. QUANDO o usuário enviar um e-mail com formato inválido
+   O SISTEMA DEVE exibir um erro de validação inline antes do envio do formulário.
+
+4. QUANDO o usuário enviar uma senha com menos de 8 caracteres
+   O SISTEMA DEVE exibir "A senha deve ter pelo menos 8 caracteres."
+
+---
+
+### 2. Login
+
+**História:** Como usuário cadastrado, quero fazer login com minhas credenciais,
+para que eu possa acessar minha conta.
+
+#### Critérios de Aceitação
+
+1. QUANDO o usuário enviar credenciais válidas
+   O SISTEMA DEVE criar uma sessão autenticada e redirecionar para o painel principal.
+
+2. SE o usuário enviar credenciais inválidas 5 vezes consecutivas
+   ENTÃO O SISTEMA DEVE bloquear a conta por 15 minutos e exibir
+   "Muitas tentativas falhas. Tente novamente em 15 minutos."
+
+3. QUANDO o usuário enviar credenciais inválidas (abaixo do limite de bloqueio)
+   O SISTEMA DEVE exibir "E-mail ou senha inválidos" sem revelar qual campo
+   está incorreto.
+
+---
+
+### 3. Redefinição de Senha
+
+**História:** Como usuário que esqueceu minha senha, quero redefini-la por
+e-mail, para que eu possa recuperar o acesso à minha conta.
+
+#### Critérios de Aceitação
+
+1. QUANDO o usuário solicitar redefinição de senha para um e-mail cadastrado
+   O SISTEMA DEVE enviar um link de redefinição válido por 1 hora para esse endereço.
+
+2. QUANDO o usuário solicitar redefinição de senha para um e-mail não cadastrado
+   O SISTEMA DEVE exibir a mesma mensagem de confirmação de um e-mail cadastrado
+   (para evitar enumeração de contas).
+
+3. QUANDO o usuário clicar em um link de redefinição expirado ou já utilizado
+   O SISTEMA DEVE exibir "Este link expirou. Solicite um novo."
+
+4. QUANDO o usuário enviar uma nova senha via link de redefinição válido
+   O SISTEMA DEVE atualizar a senha, invalidar o token de redefinição e
+   redirecionar para a página de login.
+
+---
+
+### 4. Logout
+
+**História:** Como usuário autenticado, quero me desconectar, para que minha
+sessão seja encerrada neste dispositivo.
+
+#### Critérios de Aceitação
+
+1. QUANDO o usuário clicar em "Sair"
+   O SISTEMA DEVE invalidar o token de sessão e redirecionar para a página
+   de login.
+
+2. ENQUANTO uma sessão estiver invalidada
+   O SISTEMA DEVE rejeitar qualquer requisição subsequente usando o token
+   antigo com resposta 401.

--- a/config/cursor/skills/ears/assets/examples/requirements-first/tasks.md
+++ b/config/cursor/skills/ears/assets/examples/requirements-first/tasks.md
@@ -1,0 +1,43 @@
+# Tarefas: Autenticação de Usuários
+
+- [ ] 1. Configurar schema do banco de dados e repositórios
+  - Criar tabela `users` com `id`, `email`, `password_hash`, `created_at`, `updated_at`
+  - Criar tabela `reset_tokens` com `id`, `user_id`, `token`, `expires_at`, `used_at`
+  - Implementar `UserRepository.buscarPorEmail()` e `UserRepository.criar()`
+  - Implementar `ResetTokenRepository.criar()`, `buscarPorToken()` e `marcarComoUsado()`
+  - **Requisitos:** 1.1, 3.1, 3.4
+
+- [ ] 2. Implementar endpoint de cadastro
+  - `POST /auth/cadastro` — validar formato de e-mail e tamanho de senha
+  - Gerar hash da senha com bcrypt (fator de custo 12)
+  - Retornar 409 se o e-mail já existir
+  - Retornar 201 e JWT em caso de sucesso
+  - **Requisitos:** 1.1, 1.2, 1.3, 1.4
+
+- [ ] 3. Implementar endpoint de login com proteção contra força bruta
+  - `POST /auth/login` — validar credenciais contra o hash armazenado
+  - Incrementar contador Redis de tentativas falhas em caso de falha
+  - Bloquear conta por 15 minutos após 5 falhas consecutivas
+  - Retornar mensagem genérica 401 (sem revelar o campo incorreto)
+  - Zerar contador após login bem-sucedido
+  - **Requisitos:** 2.1, 2.2, 2.3
+
+- [ ] 4. Implementar fluxo de redefinição de senha
+  - `POST /auth/redefinir-senha` — gerar token de redefinição, enviar e-mail via MailService
+  - Retornar resposta idêntica para e-mails cadastrados e não cadastrados
+  - `POST /auth/confirmar-redefinicao` — validar token, verificar expiração e `used_at`
+  - Atualizar hash da senha, marcar token como usado, redirecionar para login
+  - **Requisitos:** 3.1, 3.2, 3.3, 3.4
+
+- [ ] 5. Implementar endpoint de logout
+  - `POST /auth/logout` — invalidar token de sessão (adicionar à denylist ou limpar cookie)
+  - Retornar 401 para requisições subsequentes usando o token antigo
+  - **Requisitos:** 4.1, 4.2
+
+- [ ] 6. Escrever testes
+  - Unitários: `AuthService` — validação de credenciais, contador de bloqueio, expiração de token
+  - Integração: fluxo cadastro → login → logout contra banco de teste
+  - Integração: fluxo completo de redefinição de senha com MailService mock
+  - E2E: caminho feliz de login via interface
+  - E2E: bloqueio por força bruta (5 tentativas falhas)
+  - **Requisitos:** 1.1–1.4, 2.1–2.3, 3.1–3.4, 4.1–4.2

--- a/config/cursor/skills/ears/references/EARS.md
+++ b/config/cursor/skills/ears/references/EARS.md
@@ -1,0 +1,115 @@
+# Referência Rápida — EARS
+
+EARS (Easy Approach to Requirements Syntax) restringe requisitos em linguagem
+natural a padrões determinísticos e testáveis.
+
+---
+
+## Padrão Principal do Kiro
+
+O Kiro usa uma forma simplificada de duas cláusulas para a maioria dos
+requisitos de produto:
+
+```
+QUANDO <condição ou evento de disparo>
+O SISTEMA DEVE <comportamento esperado>
+```
+
+Use este como padrão para todos os critérios de aceitação.
+
+---
+
+## Padrões Completos do EARS
+
+Use estes quando a forma simplificada perder nuance importante.
+
+### Ubíquo — sempre ativo, sem condição
+
+```
+O SISTEMA DEVE <resposta>
+```
+
+Exemplo:
+```
+O SISTEMA DEVE responder a todas as requisições da API em menos de 500ms
+sob carga normal.
+```
+
+### Orientado a Estado — ativo enquanto uma condição se mantém
+
+```
+ENQUANTO <pré-condição>
+O SISTEMA DEVE <resposta>
+```
+
+Exemplo:
+```
+ENQUANTO a sessão do usuário estiver expirada
+O SISTEMA DEVE redirecionar todas as requisições para /login.
+```
+
+### Orientado a Evento — disparado por um evento (padrão do Kiro)
+
+```
+QUANDO <gatilho>
+O SISTEMA DEVE <resposta>
+```
+
+Exemplo:
+```
+QUANDO o usuário enviar o formulário de checkout
+O SISTEMA DEVE validar todos os campos obrigatórios antes de processar
+o pagamento.
+```
+
+### Comportamento Indesejado — tratamento de erros e edge cases
+
+```
+SE <gatilho indesejado>
+ENTÃO O SISTEMA DEVE <resposta>
+```
+
+Exemplo:
+```
+SE o gateway de pagamento retornar um erro de timeout
+ENTÃO O SISTEMA DEVE exibir "Não foi possível processar o pagamento.
+Tente novamente."
+```
+
+### Complexo — pré-condição + gatilho combinados
+
+```
+ENQUANTO <pré-condição>
+QUANDO <gatilho>
+O SISTEMA DEVE <resposta>
+```
+
+Exemplo:
+```
+ENQUANTO o carrinho contiver ao menos um item
+QUANDO o usuário clicar em "Finalizar Compra"
+O SISTEMA DEVE exibir a tela de resumo do pedido.
+```
+
+---
+
+## Regras
+
+1. A ordem das cláusulas é sempre: ENQUANTO → QUANDO/SE → DEVE. Nunca reordene.
+2. Cada requisito tem exatamente um nome de sistema e uma ou mais respostas.
+3. Divida comportamentos compostos: evite "e" para encadear respostas não relacionadas.
+4. Evite "não" como verbo principal — use o padrão de Comportamento Indesejado.
+5. Evite termos vagos: "adequado", "amigável", "conforme necessário", "rapidamente".
+6. Cada critério deve ser testável de forma independente.
+
+---
+
+## Escolhendo o Padrão Correto
+
+| Situação | Padrão |
+|---|---|
+| Comportamento padrão de produto | Orientado a Evento (`QUANDO … DEVE`) |
+| Restrição sempre ativa | Ubíquo (`DEVE`) |
+| Modo ou estado de sessão | Orientado a Estado (`ENQUANTO … DEVE`) |
+| Caso de erro ou falha | Comportamento Indesejado (`SE … ENTÃO DEVE`) |
+| Estado + evento combinados | Complexo (`ENQUANTO … QUANDO … DEVE`) |

--- a/config/cursor/skills/ears/references/FORMATS.md
+++ b/config/cursor/skills/ears/references/FORMATS.md
@@ -1,0 +1,188 @@
+# Formatos dos Arquivos
+
+Formato exato para cada artefato gerado. Siga estes templates à risca.
+
+## Layout canônico (sobrescreve o template do repositório)
+
+Quando o workspace contiver **`docs/example/requirements.md`**, **`docs/example/design.md`** e **`docs/example/tasks.md`**:
+
+- **Esses arquivos definem o layout**, não só este documento: replique **ordem de seções**, **níveis de heading** (`#`, `##`, `###`, `####`) e **padrões estruturais** (glossário, definição de pronto, requisitos numerados, subseções de contrato HTTP, etc.).
+- Os templates abaixo são **fallback** quando `docs/example/*.md` **não** existir.
+- **Não** acrescente nem remova seções estruturais de topo em relação ao exemplo para "simplificar" ou "melhorar", salvo pedido explícito do usuário.
+
+## Papéis dos documentos (resumo)
+
+| Arquivo | Papel |
+| --- | --- |
+| `requirements.md` | Comportamentos e critérios de aceitação (EARS, em pt-BR). Aponta para o design com links. |
+| `design.md` | **Normativo**: um valor por decisão (rotas, corpos, status, políticas). Texto em pt-BR; identificadores técnicos podem ser em inglês. |
+| `tasks.md` | Sequência de trabalho e verificação; cita números de requisito + `design.md#slug`, sem duplicar o contrato. |
+
+## Links cruzados
+
+- Use **headings Markdown** como alvos de link para que o preview (Cursor, VS Code, GitHub) gere fragmentos estáveis.
+- Evite depender só de `<a id="...">` como âncora de uma subseção.
+
+## Design normativo (sem ambiguidade)
+
+Em `design.md`, para tudo que um verificador compare a um resultado esperado:
+
+- Use inteiros HTTP **literais**, **nomes exatos** de campos JSON, políticas **fixas** (ex.: DLQ após N recebimentos).
+- **Não** use: "escolha uma", "um ou outro", "antes da verificação", células placeholder "_ex.: 200_", ou dois métodos HTTP quando só um vale.
+- Se faltar decisão, **pergunte** antes de escrever a subseção.
+
+---
+
+## requirements.md
+
+```markdown
+# Requisitos: <Nome da Feature>
+
+## Visão Geral
+
+<Um parágrafo descrevendo a feature e seu propósito de negócio.>
+
+## Requisitos
+
+### 1. <Título da História de Usuário>
+
+**História:** Como <papel>, quero <capacidade>, para que <benefício>.
+
+#### Critérios de Aceitação
+
+1. QUANDO <condição>
+   O SISTEMA DEVE <comportamento>
+
+2. QUANDO <condição>
+   O SISTEMA DEVE <comportamento>
+
+3. SE <condição indesejada>
+   ENTÃO O SISTEMA DEVE <comportamento>
+
+---
+
+### 2. <Título da História de Usuário>
+
+**História:** Como <papel>, quero <capacidade>, para que <benefício>.
+
+#### Critérios de Aceitação
+
+1. QUANDO <condição>
+   O SISTEMA DEVE <comportamento>
+
+2. ENQUANTO <pré-condição>
+   QUANDO <gatilho>
+   O SISTEMA DEVE <comportamento>
+```
+
+**Regras:**
+- Critérios são numerados por história (1.1, 1.2, 2.1, …) para rastreabilidade.
+  Use o número da história como prefixo em referências cruzadas (ex.: "satisfaz 1.1").
+- Toda história precisa de ao menos um critério de caminho feliz e um de erro/edge case.
+- Com exemplo canônico no repo, seções extras dele (glossário, definição de pronto, introdução) são **esperadas** — replique a estrutura.
+- Sem exemplo, mantenha o template mínimo: não adicione status, responsável ou data salvo pedido do usuário.
+
+---
+
+## design.md
+
+```markdown
+# Design: <Nome da Feature>
+
+## Visão Geral
+
+<Descrição de alto nível da abordagem técnica e por que foi escolhida.>
+
+## Arquitetura
+
+### Componentes
+
+| Componente | Responsabilidade |
+|---|---|
+| <nome> | <O que faz> |
+| <nome> | <O que faz> |
+
+### Diagrama de Sequência
+
+```mermaid
+sequenceDiagram
+    actor Usuário
+    participant Frontend
+    participant Backend
+    participant Banco de Dados
+
+    Usuário->>Frontend: ação
+    Frontend->>Backend: requisição
+    Backend->>Banco de Dados: consulta
+    Banco de Dados-->>Backend: resultado
+    Backend-->>Frontend: resposta
+    Frontend-->>Usuário: feedback
+```
+
+## Modelos de Dados
+
+<Descreva entidades, schemas ou tipos relevantes para esta feature.>
+
+```typescript
+interface ExemploEntidade {
+  id: string
+  // ...
+}
+```
+
+## Tratamento de Erros
+
+| Cenário | Comportamento | Requisito |
+|---|---|---|
+| <Caso de erro> | <Como é tratado> | <1.3> |
+
+## Considerações Não-Funcionais
+
+<Performance, segurança, escalabilidade ou compliance relevantes para esta
+feature. Referencie números de requisito onde aplicável.>
+
+## Estratégia de Testes
+
+<Abordagem de testes unitários, de integração e e2e. Quais comportamentos
+são cobertos em cada camada.>
+```
+
+**Regras:**
+- Toda decisão de design deve referenciar ao menos um número de requisito.
+- O diagrama de sequência deve cobrir o fluxo principal do caminho feliz (quando o exemplo canônico incluir um).
+- Não invente comportamentos não cobertos pelo `requirements.md`.
+- Tabelas e subseções que definem **HTTP**, **filas** ou **observabilidade** são **normativas**: preencha por completo; veja **Design normativo** acima.
+
+---
+
+## tasks.md
+
+```markdown
+# Tarefas: <Nome da Feature>
+
+- [ ] 1. <Título de alto nível da tarefa>
+  - <Sub-tarefa concreta>
+  - <Sub-tarefa concreta>
+  - **Requisitos:** 1.1, 1.2
+
+- [ ] 2. <Título de alto nível da tarefa>
+  - <Sub-tarefa concreta>
+  - <Sub-tarefa concreta>
+  - **Requisitos:** 2.1
+
+- [ ] 3. <Tarefa de validação>
+  - Escrever testes cobrindo os critérios de aceitação 1.1, 1.2
+  - Verificar tratamento de erros para 1.3
+  - **Requisitos:** 1.1, 1.2, 1.3
+```
+
+**Regras:**
+- Tarefas são ordenadas por dependência — cada tarefa pode ser iniciada sem
+  depender de uma não-resolvida acima dela.
+- Toda tarefa referencia o(s) número(s) de requisito que satisfaz.
+- Inclua ao menos uma tarefa de validação/testes por história.
+- Sub-tarefas são concretas e acionáveis, não vagas ("implementar X", não "trabalhar em X").
+- Bullets de **verificação** devem apontar para **`design.md#…`** e critérios do
+  `requirements.md` em vez de copiar JSON ou tabelas de status inteiros.
+- Não adicione campos de status, responsável ou data — o checkbox é suficiente
+  (salvo se o exemplo canônico tiver bloco de definição de pronto no topo — replique).

--- a/config/cursor/skills/sdd/SKILL.md
+++ b/config/cursor/skills/sdd/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: sdd
+description: >
+  Produces exactly three files under docs/specs/<feature-slug>/:
+  requirements.md (behavior and acceptance, EARS), design.md (normative
+  technical contract: single source of truth for APIs, JSON payloads, HTTP
+  status codes, and operational policies), tasks.md (ordered work and
+  verification). MUST match the repository canonical example layout when
+  docs/example/{requirements,design,tasks}.md exist—same section order and
+  heading levels; do not invent top-level sections, rename stable headings,
+  or rely on custom HTML id anchors for cross-links. Design states concrete
+  values only: forbid "pick one", "either A or B", "before verification",
+  and placeholder tables (e.g. "_e.g. 200_"). Cross-links use real Markdown
+  headings so URL fragments match editor and GitHub slug rules. Use when the
+  user asks for SDD, spec, PRD, Kiro-style feature specs, or separate
+  requirements / design / tasks documents. Supports Requirements-First and
+  Design-First workflows.
+compatibility: Designed for Cursor Agent and similar agentic coding tools.
+metadata:
+  author: roalcantara
+  version: "1.1"
+---
+
+# Kiro-style Feature Spec Generator
+
+Generate a complete three-file spec for the described feature, replicating
+Kiro's spec workflow. Read [references/EARS.md](references/EARS.md) before
+writing any requirement. Read [references/FORMATS.md](references/FORMATS.md)
+before creating any file.
+
+## Non-negotiables (layout, roles, links)
+
+1. **Layout source of truth**
+   - If the workspace contains **`docs/example/requirements.md`**, **`docs/example/design.md`**, and **`docs/example/tasks.md`**, treat them as the **canonical skeleton**: **same top-level sections**, **same heading levels** (`#`, `##`, `###`, `####`), and **same patterns** (tables vs lists) as in those files. Fill content for `<feature-slug>`; **do not** substitute a different outline (for example the shorter template in FORMATS alone).
+   - If those files are **missing**, use [references/FORMATS.md](references/FORMATS.md) templates only.
+
+2. **Separation of concerns**
+   - **`requirements.md`**: *What* must hold and *how we know* (EARS acceptance criteria). **Reference** the design for specifics (`design.md#heading-slug`). **Do not** duplicate long normative tables (status codes, route matrices, JSON schemas) if they already live in `design.md`.
+   - **`design.md`**: *How* in **closed**, **verifiable** detail—routes, methods, request/response bodies, HTTP status integers, error shapes, queues, retries, DLQ, etc. This file is the **single source of truth** for those facts.
+   - **`tasks.md`**: *Order of work* plus verification steps that **point to** requirement ids **and** design headings; **do not** restate full contracts inline.
+
+3. **Anchors and cross-links**
+   - Define link targets with **real Markdown headings** (`#### 8.1 Routes table`, etc.). **Do not** depend on `<a id="...">`** for Cursor/VS Code preview.
+   - When linking from requirements or tasks to design, use fragments that match **GitHub-style slugs** from those headings (verify the heading text produces a stable slug).
+
+4. **Forbidden in normative design prose** (anything a verifier would need as a single expected value)
+   - Phrases like: "pick one", "the design chooses later", "before verification fill in", "either X or Y" for the same case, "for example" / `_e.g._` **in place of** a committed value in a canonical table.
+   - If the human has not decided a value, **ask** before writing the design section—**do not** leave open options in the shipped doc.
+
+---
+
+## Step 0 — Workflow Selection
+
+Ask the user:
+
+> "Which workflow do you want to use?
+> - **Requirements-First** — you know the desired behavior; architecture
+>   will adapt to meet it.
+> - **Design-First (High Level)** — you have a system architecture in mind;
+>   requirements will be derived from it.
+> - **Design-First (Low Level)** — you have pseudocode, interfaces, or
+>   algorithms in mind; requirements will be derived from them."
+
+Wait for explicit selection before proceeding.
+
+Derive `<feature-slug>` from the feature name (lowercase, hyphens only).
+All files go to `docs/specs/<feature-slug>/`.
+
+---
+
+## Workflow A — Requirements-First
+
+**Flow:** Requirements → Design → Tasks
+
+### Phase 1 — Requirements
+
+1. Ask clarifying questions if the feature description is ambiguous:
+   - Who are the users / roles involved?
+   - What are the main success scenarios?
+   - What are the key failure / edge cases?
+   - Are there non-functional constraints?
+
+2. Generate `docs/specs/<feature-slug>/requirements.md` following
+   [references/FORMATS.md](references/FORMATS.md#requirementsmd) **and**, when
+   present, the **section order and headings** of `docs/example/requirements.md`.
+
+3. Requirements rules:
+   - Write every acceptance criterion in EARS format (see [references/EARS.md](references/EARS.md))
+   - Use `WHEN … THE SYSTEM SHALL …` as the primary pattern
+   - Number each criterion within its story (1.1, 1.2, 2.1, …)
+   - Cover happy path, edge cases, and error handling
+
+4. **STOP. Show the file and ask:**
+   > "Here is `requirements.md`. Does this capture everything correctly?
+   > Let me know what to change before I move on to the design."
+
+   Wait for explicit approval ("looks good", "approved", "proceed", etc.)
+   before continuing.
+
+### Phase 2 — Design
+
+1. Generate `docs/specs/<feature-slug>/design.md` following
+   [references/FORMATS.md](references/FORMATS.md#designmd) **and**, when
+   present, the **section order and headings** of `docs/example/design.md`.
+
+2. Every architectural decision must trace back to at least one requirement
+   number from `requirements.md`.
+
+3. **Normative contract**: Any API, payload, status code, or policy a tester
+   could assert MUST appear **once**, **concretely**, in this file (see
+   **Non-negotiables**). No placeholder rows or deferred choices.
+
+4. Include a Mermaid sequence diagram for the main flow (unless the canonical
+   example omits it for this feature type—then match the example).
+
+5. **STOP. Show the file and ask:**
+   > "Here is `design.md`. Does the architecture look right?
+   > Any changes before I generate the tasks?"
+
+   Wait for explicit approval before continuing.
+
+### Phase 3 — Tasks
+
+1. Generate `docs/specs/<feature-slug>/tasks.md` following
+   [references/FORMATS.md](references/FORMATS.md#tasksmd) **and**, when
+   present, the **section order and headings** of `docs/example/tasks.md`.
+
+2. Tasks rules:
+   - Each task must reference the requirement number(s) it satisfies
+   - Order by dependency (no task should depend on an unresolved one above it)
+   - Include setup, implementation, and validation tasks
+   - Verification bullets should cite **`design.md#heading-slug`** (and
+     `requirements.md` ids) instead of re-embedding full status or JSON specs
+
+3. **STOP. Show the file and ask:**
+   > "Here is `tasks.md`. Ready to start implementing, or do you want to
+   > adjust anything?"
+
+---
+
+## Workflow B — Design-First
+
+**Flow:** Design → Requirements → Tasks
+
+### Phase 1 — Design
+
+1. Ask clarifying questions if needed:
+   - What are the technical constraints or required stack?
+   - Any non-functional requirements (latency, throughput, compliance)?
+   - Are there existing diagrams or architecture docs to incorporate?
+   - High Level (components, interactions) or Low Level (pseudocode,
+     interfaces)?
+
+2. Generate `docs/specs/<feature-slug>/design.md` following
+   [references/FORMATS.md](references/FORMATS.md#designmd) and, when present,
+   **`docs/example/design.md`** layout. Apply **Non-negotiables**: the design
+   must already contain **committed** technical values (no "TBD" tables).
+
+3. Include all constraints and non-functional requirements explicitly.
+
+4. **STOP. Show the file and ask:**
+   > "Here is `design.md`. Does the architecture match your intent?
+   > Iterate here before I derive the requirements from it."
+
+   Wait for explicit approval before continuing.
+
+### Phase 2 — Requirements
+
+1. Derive requirements from the confirmed design.
+
+2. Generate `docs/specs/<feature-slug>/requirements.md` following
+   [references/FORMATS.md](references/FORMATS.md#requirementsmd) and, when
+   present, **`docs/example/requirements.md`** layout.
+
+3. Requirements must be feasible given the confirmed architecture — do not
+   add behaviors the design cannot support.
+
+4. Write every acceptance criterion in EARS format (see [references/EARS.md](references/EARS.md)).
+
+5. **STOP. Show the file and ask:**
+   > "Here is `requirements.md` derived from your design. Does this reflect
+   > all the behaviors you expect? Any gaps before I generate the tasks?"
+
+   Wait for explicit approval before continuing.
+
+### Phase 3 — Tasks
+
+Same as Workflow A, Phase 3.
+
+---
+
+## General Rules
+
+- Never skip a phase or proceed without explicit user approval.
+- Never generate all three files at once.
+- If the user asks to change something after approval, update the file,
+  show the diff, and re-confirm before continuing.
+- Prefer short, unambiguous task descriptions over long prose.
+- All Mermaid diagrams must be valid and renderable.
+- **Layout**: Do not "improve" or reorganize the canonical example structure
+  unless the user explicitly asks; consistency across features matters more than
+  an agent's preferred outline.
+- **Design first for forks**: If requirements mention "per design §…" or link
+  to a subsection, that subsection MUST exist and MUST contain one clear value
+  per decision.

--- a/config/cursor/skills/sdd/assets/examples/design-first/design.md
+++ b/config/cursor/skills/sdd/assets/examples/design-first/design.md
@@ -1,0 +1,107 @@
+# Design: Rate Limiter Middleware
+
+## Overview
+
+Token bucket rate limiter implemented as Express middleware, using Redis
+for distributed state. Limits are configurable per endpoint and enforced
+per user ID (authenticated) or IP address (unauthenticated).
+
+## Architecture
+
+### Components
+
+| Component | Responsibility |
+|---|---|
+| `rateLimiter()` | Express middleware factory — wraps any route with rate limiting |
+| `TokenBucket` | Core algorithm — manages token replenishment and consumption |
+| `RedisStore` | Distributed state backend — persists bucket state across instances |
+| `LimitConfig` | Per-endpoint configuration — capacity, refill rate, window |
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Express
+    participant RateLimiter
+    participant TokenBucket
+    participant Redis
+
+    Client->>Express: HTTP request
+    Express->>RateLimiter: middleware(req, res, next)
+    RateLimiter->>RateLimiter: resolveKey(req) — userId or IP
+    RateLimiter->>Redis: GET bucket:{key}
+    Redis-->>RateLimiter: bucket state | null
+    RateLimiter->>TokenBucket: consume(state, config)
+    TokenBucket->>TokenBucket: refill tokens since last request
+    TokenBucket->>TokenBucket: check if token available
+    TokenBucket-->>RateLimiter: { allowed, remaining, resetAt }
+    RateLimiter->>Redis: SET bucket:{key} newState EX ttl
+    alt allowed
+        RateLimiter->>Express: next()
+        Express-->>Client: 200 response
+    else rate limited
+        RateLimiter-->>Client: 429 Too Many Requests
+    end
+```
+
+## Data Models
+
+```typescript
+interface BucketState {
+  tokens: number       // current token count
+  lastRefillAt: number // unix timestamp ms
+}
+
+interface LimitConfig {
+  capacity: number     // max tokens (burst ceiling)
+  refillRate: number   // tokens added per second
+  windowMs: number     // Redis TTL for the bucket key
+}
+
+interface LimitResult {
+  allowed: boolean
+  remaining: number
+  resetAt: number      // unix timestamp ms when bucket is full again
+}
+```
+
+**Token bucket algorithm (pseudocode):**
+
+```
+function consume(state, config):
+  now = Date.now()
+  elapsed = now - state.lastRefillAt
+  refilled = floor(elapsed / 1000 * config.refillRate)
+  tokens = min(state.tokens + refilled, config.capacity)
+
+  if tokens >= 1:
+    return { allowed: true, tokens: tokens - 1, lastRefillAt: now }
+  else:
+    return { allowed: false, tokens: 0, lastRefillAt: now }
+```
+
+## Error Handling
+
+| Scenario | Behavior | Requirement |
+|---|---|---|
+| Redis connection failure | Fail open — allow request, log warning | 1.3 |
+| Token unavailable | 429 with `Retry-After` header | 1.1 |
+| Missing config for route | Use global default config | 2.1 |
+
+## Non-Functional Considerations
+
+- **Latency:** Redis GET + SET adds ~1ms per request on local network.
+  Acceptable for the target of <100ms overhead.
+- **Distributed correctness:** Lua script used for atomic GET + SET in Redis
+  to prevent race conditions under concurrent load.
+- **Fail-open:** If Redis is unreachable, requests are passed through
+  rather than rejected — availability is prioritised over strict limiting.
+
+## Testing Strategy
+
+- **Unit:** `TokenBucket.consume()` — refill math, burst ceiling, exhaustion.
+- **Unit:** `resolveKey()` — authenticated vs unauthenticated path.
+- **Integration:** Middleware applied to a test Express app, Redis running
+  in-process via `ioredis-mock`.
+- **Load:** Verify <100ms overhead under 1000 req/s using `autocannon`.

--- a/config/cursor/skills/sdd/assets/examples/design-first/requirements.md
+++ b/config/cursor/skills/sdd/assets/examples/design-first/requirements.md
@@ -1,0 +1,58 @@
+# Requirements: Rate Limiter Middleware
+
+## Overview
+
+Provide configurable per-endpoint rate limiting for the Express API using
+a token bucket algorithm backed by Redis, enforcing limits per user or IP.
+
+## Requirements
+
+### 1. Request Limiting
+
+**User Story:** As an API operator, I want requests to be rate-limited per
+endpoint, so that no single client can exhaust server resources.
+
+#### Acceptance Criteria
+
+1. WHEN a client exceeds the configured request limit for an endpoint
+   THE SYSTEM SHALL respond with HTTP 429 and a `Retry-After` header
+   indicating when the client may retry.
+
+2. WHEN a client is within the configured request limit
+   THE SYSTEM SHALL pass the request through to the next middleware without
+   adding more than 100ms of latency.
+
+3. IF Redis is unreachable
+   THEN THE SYSTEM SHALL allow the request through and log a warning
+   (fail-open behaviour).
+
+---
+
+### 2. Configuration
+
+**User Story:** As a developer, I want to configure different rate limits
+per endpoint, so that I can apply stricter limits to sensitive routes.
+
+#### Acceptance Criteria
+
+1. WHEN a route has no explicit limit configured
+   THE SYSTEM SHALL apply the global default limit.
+
+2. WHEN a route has an explicit limit configured
+   THE SYSTEM SHALL apply that limit instead of the global default.
+
+---
+
+### 3. Client Identification
+
+**User Story:** As an API operator, I want limits enforced per user for
+authenticated requests and per IP for unauthenticated ones, so that
+limits are fairly scoped.
+
+#### Acceptance Criteria
+
+1. WHEN a request carries a valid authentication token
+   THE SYSTEM SHALL apply the rate limit against the authenticated user ID.
+
+2. WHEN a request has no authentication token
+   THE SYSTEM SHALL apply the rate limit against the client IP address.

--- a/config/cursor/skills/sdd/assets/examples/design-first/tasks.md
+++ b/config/cursor/skills/sdd/assets/examples/design-first/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Rate Limiter Middleware
+
+- [ ] 1. Implement core TokenBucket algorithm
+  - Create `TokenBucket.consume(state, config)` with refill math
+  - Enforce burst ceiling (`min(tokens + refilled, capacity)`)
+  - Return `{ allowed, remaining, resetAt }`
+  - **Requirements:** 1.1, 1.2
+
+- [ ] 2. Implement RedisStore with atomic operations
+  - Use Lua script for atomic GET + SET to prevent race conditions
+  - Set TTL on bucket keys equal to `config.windowMs`
+  - Expose `get(key)` and `set(key, state, ttl)` methods
+  - **Requirements:** 1.2, 1.3
+
+- [ ] 3. Implement `rateLimiter()` middleware factory
+  - Accept per-route `LimitConfig`; fall back to global default if absent
+  - Resolve client key: authenticated user ID or IP address
+  - Call `RedisStore.get()` → `TokenBucket.consume()` → `RedisStore.set()`
+  - On allowed: call `next()`
+  - On denied: respond 429 with `Retry-After` header
+  - On Redis error: log warning and call `next()` (fail-open)
+  - **Requirements:** 1.1, 1.2, 1.3, 2.1, 2.2, 3.1, 3.2
+
+- [ ] 4. Write tests
+  - Unit: `TokenBucket.consume()` — refill, ceiling, exhaustion edge cases
+  - Unit: `resolveKey()` — authenticated vs unauthenticated
+  - Integration: middleware on test Express app with `ioredis-mock`
+  - Integration: Redis failure → fail-open behaviour
+  - Load: verify <100ms overhead at 1000 req/s with `autocannon`
+  - **Requirements:** 1.1, 1.2, 1.3, 2.1, 2.2, 3.1, 3.2

--- a/config/cursor/skills/sdd/assets/examples/requirements-first/design.md
+++ b/config/cursor/skills/sdd/assets/examples/requirements-first/design.md
@@ -1,0 +1,98 @@
+# Design: User Authentication
+
+## Overview
+
+JWT-based authentication with bcrypt password hashing. A stateless token
+approach was chosen to support horizontal scaling without shared session
+storage. Brute-force protection is handled at the application layer using
+a Redis-backed attempt counter.
+
+## Architecture
+
+### Components
+
+| Component | Responsibility |
+|---|---|
+| `AuthController` | Handles HTTP routes: register, login, logout, password reset |
+| `AuthService` | Business logic: credential validation, token generation, lockout checks |
+| `UserRepository` | Persists and retrieves user records from the database |
+| `TokenService` | Issues and validates JWT access tokens and reset tokens |
+| `MailService` | Sends transactional emails (password reset) |
+| `LockoutCache` | Redis-backed store for failed attempt counts (req. 2.2) |
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend
+    participant AuthController
+    participant AuthService
+    participant UserRepository
+    participant TokenService
+
+    User->>Frontend: submit login form
+    Frontend->>AuthController: POST /auth/login
+    AuthController->>AuthService: validateCredentials(email, password)
+    AuthService->>UserRepository: findByEmail(email)
+    UserRepository-->>AuthService: user | null
+    AuthService->>AuthService: checkLockout(email)
+    AuthService->>AuthService: bcrypt.compare(password, hash)
+    AuthService->>TokenService: issueAccessToken(userId)
+    TokenService-->>AuthService: jwt
+    AuthService-->>AuthController: { token }
+    AuthController-->>Frontend: 200 { token }
+    Frontend-->>User: redirect to dashboard
+```
+
+## Data Models
+
+```typescript
+interface User {
+  id: string           // UUID
+  email: string        // unique, lowercase
+  passwordHash: string // bcrypt, cost factor 12
+  createdAt: Date
+  updatedAt: Date
+}
+
+interface ResetToken {
+  id: string
+  userId: string
+  token: string        // cryptographically random, 32 bytes hex
+  expiresAt: Date      // now + 1 hour (req. 3.1)
+  usedAt: Date | null  // null until consumed (req. 3.3)
+}
+```
+
+## Error Handling
+
+| Scenario | Behavior | Requirement |
+|---|---|---|
+| Duplicate email on register | 409 + display "Email already registered" | 1.2 |
+| Invalid email format | 422 + inline field error | 1.3 |
+| Password too short | 422 + inline field error | 1.4 |
+| Invalid login credentials | 401 + generic message | 2.3 |
+| 5th failed login attempt | 423 + lockout message + 15-min Redis TTL | 2.2 |
+| Unregistered email on reset | 200 + same message as registered (enumeration guard) | 3.2 |
+| Expired or used reset link | 410 + "This link has expired" message | 3.3 |
+| Request with invalidated token | 401 | 4.2 |
+
+## Non-Functional Considerations
+
+- **Security:** Passwords hashed with bcrypt cost factor 12. Reset tokens are
+  32-byte cryptographically random values stored hashed in the DB.
+- **Brute-force protection:** Failed attempt counter stored in Redis with a
+  15-minute TTL per email (req. 2.2). Counter resets on successful login.
+- **Token lifetime:** JWT access tokens expire in 1 hour. Refresh token
+  strategy is out of scope for this spec.
+- **Account enumeration:** Password reset flow returns identical responses for
+  registered and unregistered emails (req. 3.2).
+
+## Testing Strategy
+
+- **Unit:** `AuthService` credential validation, lockout logic, token
+  expiry checks.
+- **Integration:** Full register → login → logout flow against a test
+  database. Password reset end-to-end with a mock mail server.
+- **E2E:** Happy path login and brute-force lockout via the UI.

--- a/config/cursor/skills/sdd/assets/examples/requirements-first/requirements.md
+++ b/config/cursor/skills/sdd/assets/examples/requirements-first/requirements.md
@@ -1,0 +1,88 @@
+# Requirements: User Authentication
+
+## Overview
+
+Allow users to register, log in, reset forgotten passwords, and log out
+securely. The system must prevent brute-force attacks and validate email
+formats before account creation.
+
+## Requirements
+
+### 1. User Registration
+
+**User Story:** As a new user, I want to create an account with my email
+and password, so that I can access the platform.
+
+#### Acceptance Criteria
+
+1. WHEN a user submits a valid email and password
+   THE SYSTEM SHALL create a new account and redirect to the dashboard.
+
+2. WHEN a user submits an email that already exists
+   THE SYSTEM SHALL display "Email already registered" and not create a
+   duplicate account.
+
+3. WHEN a user submits an invalid email format
+   THE SYSTEM SHALL display an inline validation error before form submission.
+
+4. WHEN a user submits a password shorter than 8 characters
+   THE SYSTEM SHALL display "Password must be at least 8 characters."
+
+---
+
+### 2. User Login
+
+**User Story:** As a registered user, I want to log in with my credentials,
+so that I can access my account.
+
+#### Acceptance Criteria
+
+1. WHEN a user submits valid credentials
+   THE SYSTEM SHALL create an authenticated session and redirect to the dashboard.
+
+2. IF a user submits invalid credentials 5 times in a row
+   THEN THE SYSTEM SHALL lock the account for 15 minutes and display
+   "Too many failed attempts. Try again in 15 minutes."
+
+3. WHEN a user submits invalid credentials (below the lockout threshold)
+   THE SYSTEM SHALL display "Invalid email or password" without revealing
+   which field is incorrect.
+
+---
+
+### 3. Password Reset
+
+**User Story:** As a user who forgot my password, I want to reset it via
+email, so that I can regain access to my account.
+
+#### Acceptance Criteria
+
+1. WHEN a user requests a password reset for a registered email
+   THE SYSTEM SHALL send a reset link valid for 1 hour to that address.
+
+2. WHEN a user requests a password reset for an unregistered email
+   THE SYSTEM SHALL display the same confirmation message as a registered
+   email (to prevent account enumeration).
+
+3. WHEN a user clicks an expired or already-used reset link
+   THE SYSTEM SHALL display "This link has expired. Request a new one."
+
+4. WHEN a user submits a new password via a valid reset link
+   THE SYSTEM SHALL update the password, invalidate the reset token, and
+   redirect to the login page.
+
+---
+
+### 4. Logout
+
+**User Story:** As an authenticated user, I want to log out, so that my
+session is terminated on this device.
+
+#### Acceptance Criteria
+
+1. WHEN a user clicks "Logout"
+   THE SYSTEM SHALL invalidate the session token and redirect to the login page.
+
+2. WHILE a session is invalidated
+   THE SYSTEM SHALL reject any subsequent requests using the old token
+   with a 401 response.

--- a/config/cursor/skills/sdd/assets/examples/requirements-first/tasks.md
+++ b/config/cursor/skills/sdd/assets/examples/requirements-first/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: User Authentication
+
+- [ ] 1. Set up database schema and repositories
+  - Create `users` table with `id`, `email`, `password_hash`, `created_at`, `updated_at`
+  - Create `reset_tokens` table with `id`, `user_id`, `token`, `expires_at`, `used_at`
+  - Implement `UserRepository.findByEmail()` and `UserRepository.create()`
+  - Implement `ResetTokenRepository.create()`, `findByToken()`, and `markUsed()`
+  - **Requirements:** 1.1, 3.1, 3.4
+
+- [ ] 2. Implement registration endpoint
+  - `POST /auth/register` — validate email format and password length
+  - Hash password with bcrypt (cost factor 12)
+  - Return 409 if email already exists
+  - Return 201 and JWT on success
+  - **Requirements:** 1.1, 1.2, 1.3, 1.4
+
+- [ ] 3. Implement login endpoint with brute-force protection
+  - `POST /auth/login` — validate credentials against stored hash
+  - Increment Redis failed-attempt counter on failure
+  - Lock account for 15 minutes after 5 consecutive failures
+  - Return generic 401 message (no field disclosure)
+  - Reset counter on successful login
+  - **Requirements:** 2.1, 2.2, 2.3
+
+- [ ] 4. Implement password reset flow
+  - `POST /auth/reset-request` — generate reset token, send email via MailService
+  - Return identical response for registered and unregistered emails
+  - `POST /auth/reset-confirm` — validate token, check expiry and `used_at`
+  - Update password hash, mark token as used, redirect to login
+  - **Requirements:** 3.1, 3.2, 3.3, 3.4
+
+- [ ] 5. Implement logout endpoint
+  - `POST /auth/logout` — invalidate session token (add to denylist or clear cookie)
+  - Return 401 for subsequent requests using the old token
+  - **Requirements:** 4.1, 4.2
+
+- [ ] 6. Write tests
+  - Unit: `AuthService` — credential validation, lockout counter, token expiry
+  - Integration: register → login → logout flow against test DB
+  - Integration: full password reset flow with mock MailService
+  - E2E: happy path login via UI
+  - E2E: brute-force lockout (5 failed attempts)
+  - **Requirements:** 1.1–1.4, 2.1–2.3, 3.1–3.4, 4.1–4.2

--- a/config/cursor/skills/sdd/references/EARS.md
+++ b/config/cursor/skills/sdd/references/EARS.md
@@ -1,0 +1,111 @@
+# EARS Quick Reference
+
+EARS (Easy Approach to Requirements Syntax) constrains natural language
+requirements into deterministic, testable patterns.
+
+---
+
+## Kiro's Primary Pattern
+
+Kiro uses a simplified two-clause form for most product requirements:
+
+```
+WHEN <condition or triggering event>
+THE SYSTEM SHALL <expected behavior>
+```
+
+Use this as your default for all acceptance criteria.
+
+---
+
+## Full EARS Patterns
+
+Use these when the simplified form loses important nuance.
+
+### Ubiquitous — always active, no condition
+
+```
+THE SYSTEM SHALL <response>
+```
+
+Example:
+```
+THE SYSTEM SHALL respond to all API requests within 500ms under normal load.
+```
+
+### State-driven — active while a condition holds
+
+```
+WHILE <precondition>
+THE SYSTEM SHALL <response>
+```
+
+Example:
+```
+WHILE the user session is expired
+THE SYSTEM SHALL redirect all requests to /login.
+```
+
+### Event-driven — triggered by an event (Kiro's default)
+
+```
+WHEN <trigger>
+THE SYSTEM SHALL <response>
+```
+
+Example:
+```
+WHEN a user submits the checkout form
+THE SYSTEM SHALL validate all required fields before processing payment.
+```
+
+### Unwanted behaviour — error and edge case handling
+
+```
+IF <undesired trigger>
+THEN THE SYSTEM SHALL <response>
+```
+
+Example:
+```
+IF the payment gateway returns a timeout error
+THEN THE SYSTEM SHALL display "Payment could not be processed. Please try again."
+```
+
+### Complex — precondition + trigger combined
+
+```
+WHILE <precondition>
+WHEN <trigger>
+THE SYSTEM SHALL <response>
+```
+
+Example:
+```
+WHILE the cart contains at least one item
+WHEN the user clicks "Checkout"
+THE SYSTEM SHALL present the order summary screen.
+```
+
+---
+
+## Rules
+
+1. Clause order is always: WHILE → WHEN/IF → SHALL. Never reorder.
+2. Each requirement has exactly one system name and one or more system responses.
+3. Split compound behaviors: avoid "and" to chain unrelated responses.
+4. Avoid "not" as the primary verb — use the Unwanted Behaviour pattern instead.
+5. Avoid vague terms: "appropriate", "user-friendly", "as needed", "quickly".
+6. Every criterion must be independently testable.
+
+---
+
+## Choosing the Right Pattern
+
+| Situation | Pattern |
+|---|---|
+| Default product behavior | Event-driven (`WHEN … SHALL`) |
+| Always-on constraint | Ubiquitous (`SHALL`) |
+| Mode or session state | State-driven (`WHILE … SHALL`) |
+| Error / failure case | Unwanted behaviour (`IF … THEN SHALL`) |
+| State + event combined | Complex (`WHILE … WHEN … SHALL`) |

--- a/config/cursor/skills/sdd/references/FORMATS.md
+++ b/config/cursor/skills/sdd/references/FORMATS.md
@@ -1,0 +1,188 @@
+# File Formats
+
+Exact format for each generated artifact. Follow these templates precisely.
+
+## Canonical layout (repository override)
+
+When the workspace contains **`docs/example/requirements.md`**, **`docs/example/design.md`**, and **`docs/example/tasks.md`**:
+
+- **Those files define layout**, not only this document: match their **section order**, **heading levels**, and **structural patterns** (for example glossary, definition of done, numbered requirements, HTTP contract subsections).
+- The templates below are the **fallback** when `docs/example/*.md` do **not** exist.
+- **Do not** add or remove top-level structural sections relative to the example to "simplify" or "improve" unless the user explicitly requests a change.
+
+## Document roles (short)
+
+| File | Role |
+| --- | --- |
+| `requirements.md` | Behaviors and acceptance criteria (EARS). Links into `design.md` for concrete values. |
+| `design.md` | **Normative** technical contract: one value per decision (routes, bodies, status codes, policies). |
+| `tasks.md` | Sequenced work and verification; cites requirement ids + `design.md#slug`, not duplicate specs. |
+
+## Cross-links
+
+- Use **Markdown headings** as link targets so previews (Cursor, VS Code, GitHub) generate stable fragments.
+- Avoid `<a id="...">` as the **only** anchor for a subsection.
+
+## Normative design (no ambiguity)
+
+In `design.md`, for anything a verifier compares to an expected outcome:
+
+- Use **literal** HTTP status integers, **exact** JSON field names, **fixed** policies (for example DLQ after N receives).
+- **Do not** use: "pick one", "either … or …", "before verification", placeholder cells like "_e.g. 200_", or "PUT or PATCH" when only one method applies.
+- If a decision is unknown, **ask the user** before writing that subsection.
+
+---
+
+## requirements.md
+
+```markdown
+# Requirements: <Feature Name>
+
+## Overview
+
+<One paragraph describing the feature and its business purpose.>
+
+## Requirements
+
+### 1. <User Story Title>
+
+**User Story:** As a <role>, I want <capability>, so that <benefit>.
+
+#### Acceptance Criteria
+
+1. WHEN <condition>
+   THE SYSTEM SHALL <behavior>
+
+2. WHEN <condition>
+   THE SYSTEM SHALL <behavior>
+
+3. IF <undesired condition>
+   THEN THE SYSTEM SHALL <behavior>
+
+---
+
+### 2. <User Story Title>
+
+**User Story:** As a <role>, I want <capability>, so that <benefit>.
+
+#### Acceptance Criteria
+
+1. WHEN <condition>
+   THE SYSTEM SHALL <behavior>
+
+2. WHILE <precondition>
+   WHEN <trigger>
+   THE SYSTEM SHALL <behavior>
+```
+
+**Rules:**
+- Criteria are numbered per story (1.1, 1.2, 2.1, …) for traceability.
+  Use the story number as prefix in cross-references (e.g. "satisfies 1.1").
+- Every story needs at least one happy-path criterion and one error/edge criterion.
+- When a canonical example exists, **its** extra sections (glossary, definition of done, introduction) are **allowed** and expected—match the example.
+- Without an example, keep the template minimal: do not add status, owner, or date fields unless the user asks.
+
+---
+
+## design.md
+
+```markdown
+# Design: <Feature Name>
+
+## Overview
+
+<High-level description of the technical approach and why it was chosen.>
+
+## Architecture
+
+### Components
+
+| Component | Responsibility |
+|---|---|
+| <Name> | <What it does> |
+| <Name> | <What it does> |
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend
+    participant Backend
+    participant Database
+
+    User->>Frontend: action
+    Frontend->>Backend: request
+    Backend->>Database: query
+    Database-->>Backend: result
+    Backend-->>Frontend: response
+    Frontend-->>User: feedback
+```
+
+## Data Models
+
+<Describe entities, schemas, or types relevant to this feature.>
+
+```typescript
+interface ExampleEntity {
+  id: string
+  // ...
+}
+```
+
+## Error Handling
+
+| Scenario | Behavior | Requirement |
+|---|---|---|
+| <Error case> | <How it's handled> | <1.3> |
+
+## Non-Functional Considerations
+
+<Performance, security, scalability, or compliance notes relevant to this
+feature. Reference requirement numbers where applicable.>
+
+## Testing Strategy
+
+<Unit, integration, and e2e approach. Which behaviors are covered at which
+layer.>
+```
+
+**Rules:**
+- Every design decision must reference at least one requirement number.
+- The sequence diagram must cover the main happy-path flow (when the canonical example includes one).
+- Do not invent behaviors not covered by `requirements.md`.
+- Tables and subsections that define **HTTP**, **queues**, or **observability** are **normative**: fill them completely; see **Normative design** above.
+
+---
+
+## tasks.md
+
+```markdown
+# Tasks: <Feature Name>
+
+- [ ] 1. <High-level task title>
+  - <Concrete sub-task>
+  - <Concrete sub-task>
+  - **Requirements:** 1.1, 1.2
+
+- [ ] 2. <High-level task title>
+  - <Concrete sub-task>
+  - <Concrete sub-task>
+  - **Requirements:** 2.1
+
+- [ ] 3. <Validation task>
+  - Write tests covering acceptance criteria 1.1, 1.2
+  - Verify error handling for 1.3
+  - **Requirements:** 1.1, 1.2, 1.3
+```
+
+**Rules:**
+- Tasks are ordered by dependency — each task can be started without
+  blocking on an unresolved task above it.
+- Every task references the requirement number(s) it satisfies.
+- Include at least one validation/testing task per story.
+- Sub-tasks are concrete and actionable, not vague ("implement X", not "work on X").
+- **Verification** sub-bullets should point to **`design.md#…`** and requirement
+  criteria for expected outcomes, instead of copying full JSON or status tables.
+- Do not add status fields, owners, or dates — the checkbox is enough (unless
+  the canonical example uses a definition-of-done block at the top—then match it).

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -89,11 +89,6 @@ idiomatic_version_file_enable_tools = [
 # Instead use https://usage.jdx.dev/spec
 task.disable_spec_from_run_scripts = true
 
-# Change output style when executing tasks: keep-order | prefix | interleave | replacing | timed | quiet | silent
-# This controls the output of mise run. (see Tasks Runner for more)
-# https://mise.jdx.dev/configuration/settings.html#task_output
-task_output = "quiet"  # stream one task's output live while buffering others, printing in definition order as tasks complete
-
 [tools]
 watchexec = "latest"
 usage = "latest"

--- a/config/vscode/settings.json
+++ b/config/vscode/settings.json
@@ -1415,6 +1415,12 @@
         "**/devcontainer.json"
       ],
       "url": "https://raw.githubusercontent.com/devcontainers/spec/refs/heads/main/schemas/devContainer.schema.json"
+    },
+    {
+      "fileMatch": [
+        "**/samconfig.toml"
+      ],
+      "url": "https://raw.githubusercontent.com/aws/aws-sam-cli/master/schema/samcli.json"
     }
   ],
   "mise.teraAutoCompletion": true,
@@ -1633,10 +1639,13 @@
   "javascript.referencesCodeLens.showOnAllFunctions": true,
   "containers.orchestratorClient": "com.microsoft.visualstudio.orchestrators.dockercompose",
   "githubPullRequests.pushBranch": "always",
-  "workbench.colorTheme": "Catppuccin Macchiato",
-  "workbench.iconTheme": "material-icon-theme",
   "atlascode.jira.enabled": true,
   "atlascode.bitbucket.enabled": true,
   "atlascode.rovodev.showEntitlementNotifications": false,
-  "atlascode.jira.startWorkBranchTemplate.customTemplate": "{{{prefix}}}{{{issueKey}}}"
+  "atlascode.jira.startWorkBranchTemplate.customTemplate": "{{{prefix}}}{{{issueKey}}}",
+  "workbench.colorTheme": "Catppuccin Macchiato",
+  "workbench.iconTheme": "material-icon-theme",
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/config/zsh/etc/functions/gitx
+++ b/config/zsh/etc/functions/gitx
@@ -623,43 +623,57 @@ _gitx_fzus() {
 # Fzf over log; Enter = rebase-from (same UI as gitx lol; keys still work).
 # * @example: gitx fzr
 _gitx_fzr() {
-  _gitx_fzlog rebase-from "$@"
+  local hash
+  hash=$(_gitx_fzlog)
+  [[ -n "$hash" ]] && _gitx_rebase_from "${hash}"
 }
 
 # Fzf over log; Enter = fix + status (same UI as gitx lol).
 # * @example: gitx fzf
 _gitx_fzf() {
-  _gitx_fzlog fix "$@"
+  local hash
+  hash=$(_gitx_fzlog)
+  [[ -n "$hash" ]] && _gitx_fix "${hash}"
 }
 
 # Fzf over log; Enter = reword (same UI as gitx lol).
 # * @example: gitx fzw
 _gitx_fzw() {
-  _gitx_fzlog reword "$@"
+  local hash
+  hash=$(_gitx_fzlog)
+  [[ -n "$hash" ]] && _gitx_reword "${hash}"
 }
 
 # Fzf over log; Enter = edit (same UI as gitx lol).
 # * @example: gitx fze
 _gitx_fze() {
-  _gitx_fzlog edit "$@"
+  local hash
+  hash=$(_gitx_fzlog)
+  [[ -n "$hash" ]] && _gitx_edit "${hash}"
 }
 
 # Fzf over log; Enter = drop (same UI as gitx lol).
 # * @example: gitx fzd
 _gitx_fzd() {
-  _gitx_fzlog drop "$@"
+  local hash
+  hash=$(_gitx_fzlog)
+  [[ -n "$hash" ]] && _gitx_drop "${hash}"
 }
 
 # Fzf over log; Enter = reset --soft to parent (same UI as gitx lol).
 # * @example: gitx fzhs
 _gitx_fzhs() {
-  _gitx_fzlog reset-soft "$@"
+  local hash
+  hash=$(_gitx_fzlog)
+  [[ -n "$hash" ]] && git reset --soft "${hash}^" && git status --short --branch
 }
 
 # Fzf over log; Enter = reset --hard to parent (same UI as gitx lol).
 # * @example: gitx fzhh
 _gitx_fzhh() {
-  _gitx_fzlog reset-hard "$@"
+  local hash
+  hash=$(_gitx_fzlog)
+  [[ -n "$hash" ]] && git reset --hard "${hash}^"
 }
 
 # Fzf over staged files; unstage from index (git rm --cached).

--- a/install
+++ b/install
@@ -7,7 +7,7 @@
 #   DOTS_EMBEDDED=1 ./install   # or -e: use files already at ~/.local/share/dots; do not clone/pull or strip .git
 set -eu
 declare -g -A COLORS=([E]='\033[0;31m' [F]='\033[0;31m' [S]='\033[0;32m' [W]='\033[1;33m' [I]='\033[0;34m' [MAGENTA]='\033[0;35m' [NC]='\033[0m')
-declare -g USERNAME GROUPNAME TIMEZONE="America/Sao_Paulo" REPO_URL="https://github.com/roalcantara/dots" BRANCH="main" USR_LOCAL_BIN="/usr/local/bin" PACKAGE_MANAGER="flox" FLOX_VERSION="1.11.0" CONFIGS_TO_BACKUP=".bashrc .bash_logout .bash_profile .profile .zshrc .zprofile .gitconfig .oh-my-zsh"
+declare -g USERNAME GROUPNAME TIMEZONE="America/Sao_Paulo" REPO_URL="https://github.com/roalcantara/dots" BRANCH="main" USR_LOCAL_BIN="/usr/local/bin" PACKAGE_MANAGER="flox" FLOX_VERSION="1.11.2" CONFIGS_TO_BACKUP=".bashrc .bash_logout .bash_profile .profile .zshrc .zprofile .gitconfig .oh-my-zsh"
 declare -g UNAME ARCH PLATFORM_ARCH DISTRO ENV CONTEXT HOME DOTS_SRC_DIR FLOX_PATH BACKUP_DIR
 declare -g -A PACKAGES=(
   [apt]="$HOME/.config/apt/requirements.txt"


### PR DESCRIPTION
This pull request introduces a comprehensive skill specification for the `ears` skill, designed to generate feature specs in Brazilian Portuguese (pt-BR) following a strict, example-driven workflow. It provides detailed instructions, canonical layouts, and example artifacts for both requirements-first and design-first approaches. The most significant changes are the addition of the main skill definition and complete example specs for both workflows, covering requirements, design, and tasks.

**Addition of the `ears` skill specification:**

- Added `config/cursor/skills/ears/SKILL.md`, which defines the `ears` skill for generating three-part feature specs (`requirements.md`, `design.md`, `tasks.md`) in pt-BR, with strict adherence to canonical layouts and EARS format. It details negotiation steps, workflow branching (requirements-first vs. design-first), and strict rules for normative design, linking, and user approval at each phase.

**Example artifacts for the design-first workflow:**

- Added `design.md` for a rate limiting middleware, specifying architecture, sequence diagrams, data models, error handling, non-functional considerations, and testing strategy, all in pt-BR.
- Added `requirements.md` for the same feature, listing EARS-style acceptance criteria for request limiting, configuration, and client identification.
- Added `tasks.md` outlining implementation and verification steps, referencing requirements and design sections, and including both unit and integration tests.

**Example artifacts for the requirements-first workflow:**

- Added `requirements.md` for a user authentication feature, with EARS-style acceptance criteria for registration, login, password reset, and logout.
- Added `design.md` for the authentication feature, detailing stateless JWT-based architecture, components, sequence diagrams, error handling, non-functional requirements, and testing strategy.